### PR TITLE
ARROW-6260: [Website] Use deploy key on Travis to build and push to asf-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Run the following to generate HTML files and run the web site locally.
 bundle exec jekyll serve
 ```
 
+## Automatic deployment
+
 If you're working on a fork of `apache/arrow-site`, you can get a development
 version of the site built off of your `master` branch published using GitHub
 Pages and Travis-CI. There are a couple of quick steps to enable this:
@@ -78,13 +80,41 @@ Pages and Travis-CI. There are a couple of quick steps to enable this:
 turn on GitHub Pages and set it to the gh-pages branch
 3. Go to https://travis-ci.org/account/repositories and enable Travis builds on
 your fork
-4. Go to https://github.com/settings/tokens and create a GitHub personal access
+4. Set up an auth token or deploy key:
+
+### With a personal access token:
+
+A GitHub personal access token takes the least effort to set up, but its scope
+is broader (all public repositories you have access to), so some may be worried
+about setting one in Travis (even though Travis encrypts them).
+
+1. Go to https://github.com/settings/tokens and create a GitHub personal access
 token with `public_repo` scope
-5. In the settings in Travis for your fork
+2. In the settings in Travis for your fork
 (https://travis-ci.org/$YOU/arrow-site/settings), add an environment variable
 called GITHUB_PAT, using the token you just created. To keep the token value
 secret, **do not toggle on "Display value in build log"** (i.e. the default is
 secret).
+
+### With a deploy key
+
+GitHub deploy keys are tied to a repository, so they have much narrower scope
+and aren't connected to an individual contributor, but they take a little more
+work to set up.
+
+1. On your computer, do `ssh-keygen -t rsa -b 4096 -f 'github_deploy_key' -N ''`
+2. Go to https://github.com/$YOU/arrow-site/settings/keys and put the public
+key there (found in `github_deploy_key.pub`). Check the box to give the token
+write access.
+3. In the settings in Travis for your fork
+(https://travis-ci.org/$YOU/arrow-site/settings), add an environment variable
+called DEPLOY_KEY. This takes the contents of the private key file you just
+made (`github_deploy_key`), but you have to preprocess it to escape whitespace.
+Replace the spaces ` ` in the first and last lines with `\ ` (i.e. the first
+line becomes `-----BEGIN\ OPENSSH\ PRIVATE\ KEY-----`), and replace the
+newlines with `\\n`. The result should be a very long string on a single line.
+To keep this ssh key value secret, **do not toggle on "Display value in build
+log"** (i.e. the default is secret).
 
 After doing this, commits to the master branch of your fork will be
 automatically built and published to https://$YOU.github.io/arrow-site/. This

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -39,8 +39,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         echo "Setting deploy key"
         eval $(ssh-agent -s)
         # Hack to make the key from the env var have real newlines
-        echo "${DEPLOY_KEY}" | sed -e 's/\\n/\
-/g' | ssh-add -
+        echo "${DEPLOY_KEY}" | sed -e 's/\\n/\n/g' | ssh-add -
         git clone -b ${TARGET_BRANCH} git@github.com:$TRAVIS_REPO_SLUG.git OUTPUT
     else
         echo "Using GitHub PAT"

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -3,11 +3,23 @@ set -ev
 
 if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 
-    if [ -z "${GITHUB_PAT}" ]; then
+    if [ -z "${GITHUB_PAT}" ] && [ -z "${DEPLOY_KEY}" ]; then
         # Don't build because we can't publish
-        echo "To publish the site, you must set a GITHUB_PAT at"
+        echo "To publish the site, you must set a GITHUB_PAT or DEPLOY_KEY at"
         echo "https://travis-ci.org/${TRAVIS_REPO_SLUG}/settings"
         exit 1
+    fi
+
+    if [ "${DEPLOY_KEY}" != "" ]; then
+        echo "Setting deploy key"
+        # Stick it in "scripts" because Jekyll ignores it
+        echo $DEPLOY_KEY > scripts/deploy_key
+        # Hack to make the key from the env var have real newlines
+        sed -i 's/\\n/\
+/g' scripts/deploy_key
+        chmod 600 scripts/deploy_key
+        eval $(ssh-agent -s)
+        ssh-add scripts/deploy_key
     fi
 
     # Set git config so that the author of the deployed site commit is the same
@@ -35,7 +47,12 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
     JEKYLL_ENV=production bundle exec jekyll build --baseurl="${BASE_URL}"
 
     # Publish
-    git clone -b ${TARGET_BRANCH} https://${GITHUB_PAT}@github.com/$TRAVIS_REPO_SLUG.git OUTPUT
+    if [ -z "${GITHUB_PAT}" ]; then
+        echo "Cloning with deploy key"
+        git clone -b ${TARGET_BRANCH} git@github.com:$TRAVIS_REPO_SLUG.git OUTPUT
+    else
+        git clone -b ${TARGET_BRANCH} https://${GITHUB_PAT}@github.com/$TRAVIS_REPO_SLUG.git OUTPUT
+    fi
     rsync -a --delete --exclude '/.git/' --exclude '/docs/' build/ OUTPUT/
     cd OUTPUT
 

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -37,14 +37,10 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
     # Publish
     if [ "${DEPLOY_KEY}" != "" ]; then
         echo "Setting deploy key"
-        # Stick it in "scripts" because Jekyll ignores it
-        echo $DEPLOY_KEY > scripts/deploy_key
-        # Hack to make the key from the env var have real newlines
-        sed -i 's/\\n/\
-/g' scripts/deploy_key
-        chmod 600 scripts/deploy_key
         eval $(ssh-agent -s)
-        ssh-add scripts/deploy_key
+        # Hack to make the key from the env var have real newlines
+        echo "${DEPLOY_KEY}" | sed -e 's/\\n/\
+/g' | ssh-add -
         git clone -b ${TARGET_BRANCH} git@github.com:$TRAVIS_REPO_SLUG.git OUTPUT
     else
         echo "Using GitHub PAT"

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -26,7 +26,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         TARGET_BRANCH=gh-pages
         # You could supply an alternate BASE_URL, but that's not necessary
         # because we can infer it based on GitHub Pages conventions
-        if [ -z "${BASE_URL}" ]; then
+        if [ "${BASE_URL}" = "" ]; then
             BASE_URL=$(echo $TRAVIS_REPO_SLUG | sed -e 's@.*/@/@')
         fi
     fi
@@ -50,7 +50,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         echo "Using GitHub PAT"
         git clone -b ${TARGET_BRANCH} https://${GITHUB_PAT}@github.com/$TRAVIS_REPO_SLUG.git OUTPUT
     fi
-    
+
     rsync -a --delete --exclude '/.git/' --exclude '/docs/' build/ OUTPUT/
     cd OUTPUT
 


### PR DESCRIPTION
This change enables the use of [GitHub deploy keys](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys), which are tied to a repository and not an individual (in contrast with personal access tokens). Once this is merged, we can add a key pair to the repository settings in GitHub and Travis (INFRA may be required to do one or both of those) and then commits to the website source in the `master` branch will automatically build and push the generated static site to the `asf-site` branch.