### PR TITLE
Update committer/PMC roster. Move a couple people to Emeritus status

### DIFF
--- a/committers.html
+++ b/committers.html
@@ -18,22 +18,10 @@ layout: default
 <td>Dremio</td>
 </tr>
 <tr>
-<td>Todd Lipcon</td>
-<td>PMC</td>
-<td>todd</td>
-<td>Cloudera</td>
-</tr>
-<tr>
 <td>Ted Dunning</td>
 <td>PMC</td>
 <td>tdunning</td>
 <td>MapR</td>
-</tr>
-<tr>
-<td>Michael Stack</td>
-<td>PMC</td>
-<td>stack</td>
-<td>Cloudera</td>
 </tr>
 <tr>
 <td>P. Taylor Goetz</td>
@@ -223,7 +211,7 @@ layout: default
 </tr>
 <tr>
 <td>Sebastien Binet</td>
-<td>Committer</td>
+<td>PMC</td>
 <td>sbinet</td>
 <td>CERN</td>
 </tr>
@@ -241,7 +229,7 @@ layout: default
 </tr>
 <tr>
 <td>Micah Kornfield</td>
-<td>Committer</td>
+<td>PMC</td>
 <td>emkornfield</td>
 <td>Google</td>
 </tr>
@@ -266,5 +254,32 @@ layout: default
 </tbody></table>
 
     </div> <!-- /container -->
+
+    <div class="container">
+<h2>Emeritus PMC Members</h2>
+<table class="table"><thead>
+<tr>
+<th>Name</th>
+<th>Role</th>
+<th>Alias (email is &lt;alias&gt;@apache.org)</th>
+<th>Affiliation</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>Todd Lipcon</td>
+<td>PMC</td>
+<td>todd</td>
+<td>Cloudera</td>
+</tr>
+<tr>
+<td>Michael Stack</td>
+<td>PMC</td>
+<td>stack</td>
+<td>Cloudera</td>
+</tr>
+</tbody></table>
+
+    </div> <!-- /container -->
+
   </body>
 </html>


### PR DESCRIPTION
A couple of inactive PMC members have requested to be moved to Emeritus status. They can always be restored to PMC status at a later time. 