### PR TITLE
ARROW-6497: [Website] On change to master branch, automatically make PR to asf-site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
 cache: bundler
-
-script: ./build-and-deploy.sh
+before_script:
+- sudo snap install hub --classic
+script: "./build-and-deploy.sh"
+env:
+  global:
+    secure: bLAvXfsC59dSJsYTVUHkQe6lOyCUDG5Z27Un9VrVdUdTLwQgcvR84+GCP+LndXGjf15A3x6fZdgHSMJq48k8DLPyOb1Y4hW0FBPLnrvB+bwgSdT7SdDtg18Fr8wm7Z3/+0jAkh0AjFwHGglohm2p8zKUehnij09KnDfhjs25PNOjFzdO1d78rHK072NHK/PX8p0HIQdN2KzTT5SBkE6NHgRvWeZAmSgaSrqeQE4daGw91QzucHIkxTMiDcvU1YBiCRE4GyhsjssIdedIHISDnw1BKr63RJj55B+XptWbBNCNxwPGVM45ZTj0vbUIm5cQh5kuS/LMI90DyJ/UaX7iz8YVMDQqslJlWnO2fZH6NQe6vNDz5XspaEmo5j94/w+h00yGKy6vFeAUjuq4TYf1QwkpkHQA33ja1NulLajzYEJEzwkhvZ7rl/sd4AIt142+KM6eC21lrcsDgrKQRLl16BQzgjCVKtZzD7hz01KoXD8CpPYIJfbZM5Lq26b9eKGGPs9F2PdYgUCsOqCYuoDHW/JAHVP01jR2g5e/nVQi56kl9e4XLTD/ipSLjRwkqgDde1MBsNiilGGyIFdpALyUmOEjt37AxLXBKtv5iyge0jNwPgN/g0VcQT1CPYt6Q5o6PMapAp0yOLmPJb7R4DrAJOiPlyhBjt01S/B57fw5iZY=

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -20,6 +20,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
     AUTHOR_NAME=$(git log -1 --pretty=format:%an)
     git config --global user.email "${AUTHOR_EMAIL}"
     git config --global user.name "${AUTHOR_NAME}"
+    COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
 
     if [ "${TRAVIS_REPO_SLUG}" = "${UPSTREAM}" ]; then
         # Production
@@ -61,11 +62,11 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
     if [ "$(git status --porcelain)" != "" ]; then
         # There are changes to the built site
         git add .
-        git commit -m "Updating built site (build ${TRAVIS_BUILD_NUMBER})"
+        git commit -m "Build ${COMMIT_MESSAGE}"
         git push origin ${TARGET_BRANCH}
         if [ "${TRAVIS_REPO_SLUG}" = "${UPSTREAM}" ]; then
-            git remote add upstream https://github.com/${UPSTREAM}
-            hub pull-request -b upstream:asf-site --no-edit
+            UPSTREAM_ORG=$(echo $UPSTREAM | sed -e 's@/.*@@')
+            hub pull-request -b ${UPSTREAM_ORG}:asf-site -m "Publish ${COMMIT_MESSAGE}"
         fi
     else
         echo "No changes to the built site"

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -66,7 +66,8 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         git push origin ${TARGET_BRANCH}
         if [ "${TRAVIS_REPO_SLUG}" = "${UPSTREAM}" ]; then
             UPSTREAM_ORG=$(echo $UPSTREAM | sed -e 's@/.*@@')
-            hub pull-request -b ${UPSTREAM_ORG}:asf-site -m "Publish ${COMMIT_MESSAGE}"
+            hub pull-request -b ${UPSTREAM_ORG}:asf-site -m "Publish ${COMMIT_MESSAGE}" || true
+            # `|| true` because the command errors if a PR already exists
         fi
     else
         echo "No changes to the built site"

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -ev
 
+UPSTREAM="apache/arrow-site"
+# GITHUB_TOKEN set in .travis.yml, encrypted
+# `hub` installed outside of this script, requires token called GITHUB_TOKEN with repo scope
+
 if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 
-    if [ "${GITHUB_PAT}" = "" ] && [ "${DEPLOY_KEY}" = "" ]; then
-        # Don't build because we can't publish
+    if [ "${GITHUB_PAT}" = "" ] && [ "${DEPLOY_KEY}" = "" ] && [ "${TRAVIS_REPO_SLUG}" != "${UPSTREAM}" ]; then
+        # Don't build test site because we can't publish
         echo "To publish the site, you must set a GITHUB_PAT or DEPLOY_KEY at"
         echo "https://travis-ci.org/${TRAVIS_REPO_SLUG}/settings"
         exit 1
@@ -17,10 +21,13 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
     git config --global user.email "${AUTHOR_EMAIL}"
     git config --global user.name "${AUTHOR_NAME}"
 
-    if [ "${TRAVIS_REPO_SLUG}" = "apache/arrow-site" ]; then
+    if [ "${TRAVIS_REPO_SLUG}" = "${UPSTREAM}" ]; then
         # Production
         TARGET_BRANCH=asf-site
         BASE_URL=
+        GITHUB_PAT=$GITHUB_TOKEN
+        # We're going to push to this and make a PR back to $UPSTREAM
+        DESTINATION_REPO="ursa-labs/arrow-site"
     else
         # On a fork, so we'll deploy to GitHub Pages
         TARGET_BRANCH=gh-pages
@@ -29,6 +36,8 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         if [ "${BASE_URL}" = "" ]; then
             BASE_URL=$(echo $TRAVIS_REPO_SLUG | sed -e 's@.*/@/@')
         fi
+        # We're going to push to a branch in the same repo
+        DESTINATION_REPO=$TRAVIS_REPO_SLUG
     fi
 
     # Build
@@ -40,10 +49,10 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         eval $(ssh-agent -s)
         # Hack to make the key from the env var have real newlines
         echo "${DEPLOY_KEY}" | sed -e 's/\\n/\n/g' | ssh-add -
-        git clone -b ${TARGET_BRANCH} git@github.com:$TRAVIS_REPO_SLUG.git OUTPUT
+        git clone -b ${TARGET_BRANCH} git@github.com:$DESTINATION_REPO.git OUTPUT
     else
         echo "Using GitHub PAT"
-        git clone -b ${TARGET_BRANCH} https://${GITHUB_PAT}@github.com/$TRAVIS_REPO_SLUG.git OUTPUT
+        git clone -b ${TARGET_BRANCH} https://${GITHUB_PAT}@github.com/$DESTINATION_REPO.git OUTPUT
     fi
 
     rsync -a --delete --exclude '/.git/' --exclude '/docs/' build/ OUTPUT/
@@ -54,6 +63,10 @@ if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; 
         git add .
         git commit -m "Updating built site (build ${TRAVIS_BUILD_NUMBER})"
         git push origin ${TARGET_BRANCH}
+        if [ "${TRAVIS_REPO_SLUG}" = "${UPSTREAM}" ]; then
+            git remote add upstream https://github.com/${UPSTREAM}
+            hub pull-request -b upstream:asf-site --no-edit
+        fi
     else
         echo "No changes to the built site"
     fi


### PR DESCRIPTION
See background on the [ticket](https://issues.apache.org/jira/browse/ARROW-6497). Summary: INFRA won't let us add a deploy key for Travis to automatically publish to asf-site, so this works around it by publishing to a fork and making a PR from that fork back to apache/arrow-site. 

I created a new bot GitHub user, `arrow-site-bot`, and gave it access only to the ursa-labs/arrow-site repository. That way, the personal access token it has is effectively limited in scope to that single repository (fork). All that is required is enabling Travis-CI for apache/arrow-site--no additional secrets or credentials.

To test this out, [I used my fork as "upstream"](https://github.com/nealrichardson/arrow-site/commit/772983a0b38bfa17197eac1a0238a9b81704f4a5) and made https://github.com/nealrichardson/arrow-site/pull/2.