### PR TITLE
MINOR: Fix broken links to Rust projects

### DIFF
--- a/_posts/2019-02-04-datafusion-donation.md
+++ b/_posts/2019-02-04-datafusion-donation.md
@@ -25,7 +25,7 @@ limitations under the License.
 {% endcomment %}
 -->
 
-We are excited to announce that [DataFusion](https://github.com/apache/arrow/tree/master/rust/datafusion) has been donated to the Apache Arrow project. DataFusion is an in-memory query engine for the Rust implementation of Apache Arrow.
+We are excited to announce that [DataFusion](https://github.com/apache/arrow-datafusion) has been donated to the Apache Arrow project. DataFusion is an in-memory query engine for the Rust implementation of Apache Arrow.
 
 Although DataFusion was started two years ago, it was recently re-implemented to be Arrow-native and currently has limited capabilities but does support SQL queries against iterators of RecordBatch and has support for CSV files. There are plans to [add support for Parquet files](https://issues.apache.org/jira/browse/ARROW-4466).
 

--- a/_posts/2020-10-27-rust-2.0.0-release.md
+++ b/_posts/2020-10-27-rust-2.0.0-release.md
@@ -199,9 +199,9 @@ improve the documentation.
 
 [1]: https://issues.apache.org/jira/browse/ARROW-10295?jql=project%20%3D%20ARROW%20AND%20status%20not%20in%20%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20and%20fixVersion%20%3D%202.0.0%20AND%20text%20~%20rust%20ORDER%20BY%20created%20DESC
 [2]: https://github.com/apache/arrow/tree/rust-parquet-arrow-writer
-[3]: https://github.com/apache/arrow/tree/master/rust/parquet_derive
+[3]: https://github.com/apache/arrow-rs/tree/master/parquet_derive
 [4]: https://docs.rs/datafusion/2.0.0/datafusion/dataframe/trait.DataFrame.html
-[5]: https://github.com/apache/arrow/blob/master/rust/datafusion/examples/simple_udaf.rs
+[5]: https://github.com/apache/arrow-datafusion/blob/master/datafusion-examples/examples/simple_udaf.rs
 [6]: https://arrow.apache.org/
 [7]: https://issues.apache.org/jira/browse/ARROW-3690
 [8]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20ARROW%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20in%20(Rust%2C%20%22Rust%20-%20DataFusion%22)%20AND%20labels%20%3D%20beginner

--- a/_posts/2021-04-12-ballista-donation.md
+++ b/_posts/2021-04-12-ballista-donation.md
@@ -25,7 +25,7 @@ limitations under the License.
 {% endcomment %}
 -->
 
-We are excited to announce that [Ballista](https://github.com/apache/arrow/tree/master/rust/ballista) has been donated 
+We are excited to announce that [Ballista](https://github.com/apache/arrow-datafusion/tree/master/ballista) has been donated 
 to the Apache Arrow project. 
 
 Ballista is a distributed compute platform primarily implemented in Rust, and powered by Apache Arrow. It is built
@@ -35,7 +35,7 @@ first-class citizens without paying a penalty for serialization costs.
 The foundational technologies in Ballista are:
 
 - [Apache Arrow](https://arrow.apache.org/) memory model and compute kernels for efficient processing of data.
-- [Apache Arrow DataFusion](https://github.com/apache/arrow/tree/master/rust/datafusion) query planning and 
+- [Apache Arrow DataFusion](https://github.com/apache/arrow-datafusion) query planning and 
   execution framework, extended by Ballista to provide distributed planning and execution.
 - [Apache Arrow Flight Protocol](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/) for efficient
   data transfer between processes.


### PR DESCRIPTION
Moving the Rust code to new repos broke a few links in blog posts.