### PR TITLE
ARROW-12912: [Website] Use .asf.yaml for publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,3 +18,6 @@ github:
     squash: true
     merge: false
     rebase: false
+
+publish:
+  whoami: asf-site


### PR DESCRIPTION
Because website publishing without .asf.yaml will be disabled at
2021-07-01.

arrow.apache.org should be listed with green color at
https://infra-reports.apache.org/site-source/ .