### PR TITLE
Removing extra "}}" from the Feather Python link.

### DIFF
--- a/use_cases.md
+++ b/use_cases.md
@@ -36,7 +36,7 @@ and the [Apache Parquet](https://parquet.apache.org/) format.
 
 <!-- Link to implementation matrix? -->
 
-* Feather: C++, [Python]({{ site.baseurl }}/docs/python/feather.html }}),
+* Feather: C++, [Python]({{ site.baseurl }}/docs/python/feather.html),
   [R]({{ site.baseurl }}/docs/r/reference/read_feather.html)
 * Parquet: [C++]({{ site.baseurl }}/docs/cpp/parquet.html),
   [Python]({{ site.baseurl }}/docs/python/parquet.html),


### PR DESCRIPTION
Currently, the page: https://arrow.apache.org/use_cases/ contains a python link for "Feather" with python using "https://arrow.apache.org/docs/python/feather.html%20%7D%7D" which redirects to a 404.

Instead, it seems that we should be using the following: "https://arrow.apache.org/docs/python/feather.html".