### PR TITLE
[Website] Fix Rust committers in release note for 5.0.0

### DIFF
--- a/_release/5.0.0.md
+++ b/_release/5.0.0.md
@@ -150,27 +150,58 @@ The following Apache committers merged contributed patches to Arrow repositories
 96  Antoine Pitrou
 69  Sutou Kouhei
 63  David Li
-57  Krisztián Szűcs
+59  Krisztián Szűcs
 36  Jonathan Keane
-33  Neal Richardson
 33  Benjamin Kietzman
-22  Praveen
+33  Neal Richardson
+27  Andrew Lamb
 22  Ian Cook
+22  Praveen
 21  Jorge C. Leitao
 19  Yibo Cai
+16  Dominik Moritz
 16  Joris Van den Bossche
-12  Dominik Moritz
+15  Jiayu Liu
+12  GitHub
+12  Ritchie Vink
 11  Micah Kornfield
+10  Wakahisa
+8  Jorge Leitao
+8  Raphael Taylor-Davies
+6  Daniël Heres
+5  Andy Grove
+5  Jörn Horstmann
 5  liyafan82
+5  Navin
 5  Weston Pace
+4  Ádám Lippai
+4  Marco Neumann
 3  Brian Hulette
-3  Andy Grove
-2  Uwe L. Korn
+3  Michael Edwards
+3  Roee Shlomo
 2  Eric Erhardt
-1  ishizaki
-1  Wes McKinney
-1  Kazuaki Ishizaki
+2  Gary Pennington
+2  Steven
+2  Uwe L. Korn
+2  Wes McKinney
+1  baishen
+1  Ben Chambers
+1  Boaz
 1  Bryan Cutler
+1  Chojan Shang
+1  Dmitry Patsura
+1  Edd Robinson
+1  Gang Liao
+1  hulunbier
+1  ishizaki
+1  Kazuaki Ishizaki
+1  kazuhiko kikuchi
+1  Kornelijus Survila
+1  Laurent Mazare
+1  Manish Gill
+1  Marc van Heerden
+1  Max Meldrum
+1  Yordan Pavlov
 ```
 
 ## Changelog


### PR DESCRIPTION
This fixes the problem with the Rust committers described in the comment in #131