### PR TITLE
Stop comment rendering on 5.0.0 Rust blog

### DIFF
--- a/_posts/2021-07-20-5.0.0-rs-release.md
+++ b/_posts/2021-07-20-5.0.0-rs-release.md
@@ -68,12 +68,14 @@ Here are some of the initiatives that contributors are currently working on for 
 
 # Contributors to 5.0.0:
 Again, thank you to all the contributors for this release. Here is the raw git listing:
+
 <!--
 (arrow_dev) alamb@MacBook-Pro:~/Software/arrow-rs$ git shortlog -sn 4.0.0..5.0.0
 .. list below ..
 
 Note I combined two distinct names for Jorge
 -->
+
 ```
     28  Jorge Leitao
     27  Andrew Lamb


### PR DESCRIPTION
What was meant to be comments on https://github.com/apache/arrow-site/pull/128  were rendering accidentally:

![Screen Shot 2021-07-29 at 8 01 39 AM](https://user-images.githubusercontent.com/490673/127488292-b54a7ebc-93ff-4ced-b7a9-d3bbc02d7d35.png)

