### PR TITLE
[Website] Update Rust release details info in release blog post template

### DIFF
--- a/release-announcement-template.md
+++ b/release-announcement-template.md
@@ -31,6 +31,7 @@ To use this template:
 * Copy this template file to the _posts directory, naming it YYYY-MM-DD-x.y.z-release.md
 * Replace all instances of "x.y.z" with the current release number
 * Update the date in the front matter
+* Update the URL of the Apache Arrow Rust release blog post after it is posted
 * Update all "XX" values with the appropriate numbers (you can get the resolved issues and contributors count from `_release/x.y.z.md`)
 * Fill in the various sections below. Note that the audience is the broader user community, not Arrow developers, so please write clearly using terms they will understand and care about. Delete any sections that don't have any content (as in, there are no changes to announce)
 * Delete this introductory comment
@@ -39,13 +40,14 @@ To use this template:
 
 
 The Apache Arrow team is pleased to announce the x.y.z release. This covers
-over XX months of development work and includes [**XX resolved issues**][1]
-from [**XX distinct contributors**][2]. See the Install Page to learn how to
-get the libraries for your platform.
+over XX months of development work and includes **XX commits** from
+[**XX distinct contributors**][1] in XX repositories. See the Install Page to
+learn how to get the libraries for your platform.
 
 The release notes below are not exhaustive and only expose selected highlights
 of the release. Many other bugfixes and improvements have been made: we refer
-you to the [complete changelog][3].
+you to the complete changelogs for the [`apache/arrow`][2] and
+[`apache/arrow-rs`][3] repositories.
 
 ## Community
 
@@ -80,8 +82,12 @@ For more on what’s in the x.y.z R package, see the [R changelog][4].
 
 ## Rust notes
 
+The Rust projects have moved to separate repositories outside the
+main Arrow monorepo. For notes on the x.y.z release of the Rust
+implementation, see the [Arrow Rust changelog][3] and the
+[Apache Arrow Rust x.y.z Release blog post]({% post_url YYYY-MM-DD-x.y.z-rs-release %}).
 
-[1]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20ARROW%20AND%20status%20%3D%20Resolved%20AND%20fixVersion%20%3D%20x.y.z
-[2]: {{ site.baseurl }}/release/x.y.z.html#contributors
-[3]: {{ site.baseurl }}/release/x.y.z.html
+[1]: {{ site.baseurl }}/release/x.y.z.html#contributors
+[2]: {{ site.baseurl }}/release/x.y.z.html#changelog
+[3]: https://github.com/apache/arrow-rs/blob/x.y.z/CHANGELOG.md
 [4]: {{ site.baseurl }}/docs/r/news/

--- a/release-announcement-template.md
+++ b/release-announcement-template.md
@@ -71,7 +71,6 @@ you to the complete changelogs for the [`apache/arrow`][2] and
 
 ## R notes
 
-
 For more on what’s in the x.y.z R package, see the [R changelog][4].
 
 ## Ruby and C GLib notes

--- a/release-announcement-template.md
+++ b/release-announcement-template.md
@@ -31,9 +31,9 @@ To use this template:
 * Copy this template file to the _posts directory, naming it YYYY-MM-DD-x.y.z-release.md
 * Replace all instances of "x.y.z" with the current release number
 * Update the date in the front matter
-* Update the URL of the Apache Arrow Rust release blog post after it is posted
-* Update all "XX" values with the appropriate numbers (you can get the resolved issues and contributors count from `_release/x.y.z.md`)
+* Update all "XX" values with the appropriate numbers (you can get the commits and distinct contributors count from `_release/x.y.z.md`)
 * Fill in the various sections below. Note that the audience is the broader user community, not Arrow developers, so please write clearly using terms they will understand and care about. Delete any sections that don't have any content (as in, there are no changes to announce)
+* Update the URL of the Apache Arrow Rust release blog post (or remove the link if the Rust release blog post is not yet posted at the time this is ready to be posted)
 * Delete this introductory comment
 
  -->


### PR DESCRIPTION
This updates the Rust release details in the blog post template, as a follow-up to the changes in [ARROW-12701](https://issues.apache.org/jira/browse/ARROW-12701) and  #127