### PR TITLE
ARROW-1299: [Docs] Allow trigger nightly devdocs job manually

### DIFF
--- a/.github/workflows/devdocs.yml
+++ b/.github/workflows/devdocs.yml
@@ -18,6 +18,7 @@
 name: Upload dev docs
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * *'
 


### PR DESCRIPTION
Small follow-up on https://github.com/apache/arrow-site/pull/173, so you can trigger the workflow manually from the github UI if needed