### PR TITLE
ARROW-1299: [Doc] Add the dev version to the version dropdown

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,5 +1,9 @@
 [
     {
+        "name": "7.0 (dev)",
+        "version": "dev"
+    },
+    {
         "name": "6.0 (stable)",
         "version": ""
     },


### PR DESCRIPTION
This ensures that the new dev docs will appear in the version dropdown (eg if you are on the stable docs).

