### PR TITLE
ARROW-15786: [Website] Tidy use of and linking to Arrow logo

### DIFF
--- a/powered_by.md
+++ b/powered_by.md
@@ -44,9 +44,9 @@ in descriptions is also always allowed, as in "BigCoProduct is a widget for
 Apache Arrow".
 
 Projects and documents that want to include a logo for Apache Arrow should use
-the official logo:
+the official logo, and adhere to the guidelines listed on the [Visual Identity]({{ site.baseurl }}/visual_identity/) page:
 
-<img src="{{ site.baseurl }}/img/arrow.png" style="max-width: 100%;"/>
+<img src="{{ site.baseurl }}/img/arrow-logo_horizontal_black-txt_white-bg.png" style="max-width: 100%;"/>
 
 ## Projects Powered By Apache Arrow
 


### PR DESCRIPTION
Summary:

- As it stands, this PR only touches the `powered_by` page, linking it to the `visual_identity` page and uses one of the new logo files for that page. 
- There are two additional uses of the older files on the site: the site banner on the main page uses `arrow-inverse.png`, and the navbar header uses `arrow-inverse-300px.png`. I could switch those too, but I'm not sure there's value in that: the new files have more whitespace surrounding them, so I'd have to end up recreating exact replicas of the existing files if we wanted to preserve the (IMO very nice) tight vertical spacing on the site banner and the navbar.

As far as I can tell this is all that's needed? 