### PR TITLE
ARROW-15694: [Dev] Update apache/arrow-site GitHub Actions deploy.yml website deployment workflow to support being triggered when pushing to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,8 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
+      - master # TODO (ARROW-15988): Remove master branch
   pull_request:
     branches:
       - "*"
@@ -47,7 +48,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
             github.repository == 'apache/arrow-site'
-      - name: Configure for GitHub Pages on master
+      - name: Configure for GitHub Pages on push to main or master branch # TODO (ARROW-15988): Remove master branch
         run: |
           owner=$(jq --raw-output .repository.owner.login ${GITHUB_EVENT_PATH})
           repository=$(jq --raw-output .repository.name ${GITHUB_EVENT_PATH})


### PR DESCRIPTION
# Overview

As part of the transition away from using the name `master` for the default Git branch, we need to update the GitHub Actions website deployment workflow trigger.

Since there does not appear to be any way to dynamically compute the default Git branch name in a GitHub Actions push trigger condition, this pull request adds support for pushing to either `master` or `main` as a temporary solution.

Once Apache Infra switches the default Git branch for `apache/arrow-site` to `main`, we can completely remove support for triggering the GitHub Actions website deployment workflow from `.github/workflows/deploy.yml` on pushes to `master`. This follow up work is tracked by [ARROW-15988](https://issues.apache.org/jira/browse/ARROW-15988).

# Implementation

1. Added `main` branch to `.github/workflows/deploy.yml` push trigger condition.
2. Updated the name of the associated GitHub Actions workflow step to "`Configure for GitHub Pages on push to main or master branch`".
3. I investigated using `${{ github.event.repository.default_branch }}` to dynamically compute the default Git branch name, rather than having to temporarily support both `master` and `main`. However, GitHub Actions does not appear to support this kind of variable expansion in push trigger conditions.

# Testing

1. Manually created a `main` branch in [`mathworks/arrow-site`](https://github.com/mathworks/arrow-site). When I [pushed to `main`](https://github.com/mathworks/arrow-site/actions/runs/2018637196), the `asf-site` website deployment workflow was triggered as expected. The website deployment workflow was also still triggered as expected when I [pushed to `master`](https://github.com/mathworks/arrow-site/actions/runs/2018641684).

# Future Directions

1. We need to completely remove support for triggering the GitHub Actions website deployment workflow when pushing to `master` as soon as Apache Infra switches the default Git branch over to `main` for `apache/arrow-site`. This work is tracked by [ARROW-15988](https://issues.apache.org/jira/browse/ARROW-15988).
2. We need to update the actual content of the Apache Arrow website to no longer refer to the "master" branch. This includes updating links, text snippets, and the `README.md` for `arrow-site`. There may also be other files that need to be updated, as well. This work is tracked by [ARROW-15991](https://issues.apache.org/jira/browse/ARROW-15991).

# Notes

1. Thank you to @lafiona for her help with this pull request!