### PR TITLE
ARROW-16107: [Docs] Update archery crossbox latest-prefix command

### DIFF
--- a/.github/workflows/devdocs.yml
+++ b/.github/workflows/devdocs.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Identify latest doc build
         run: |
-          echo "::set-output name=LATEST::$(archery crossbow latest-prefix --no-fetch nightly)"
+          echo "::set-output name=LATEST::$(archery crossbow latest-prefix --no-fetch nightly-tests)"
         id: build
 
       - name: Download the crossbow docs artifact


### PR DESCRIPTION
This requires https://github.com/apache/arrow/pull/12785 to be merged first, and then should hopefully get the dev docs working again.