### PR TITLE
ARROW-16583: [Website] Fix broken links in 6.0.0-release post

### DIFF
--- a/_posts/2021-10-22-6.0.0-release.md
+++ b/_posts/2021-10-22-6.0.0-release.md
@@ -147,12 +147,12 @@ This release includes improved support for dictionary arrays, as well as integra
 
 * Fixed handling of the zero value for Decimal128 `FromBigInt` [#10796](https://github.com/apache/arrow/pull/10796)
 * Fixed various "too many releases" errors in the tests allowing all tests to be run using the `assert` build tag in CI from now on, including a bug when writing slices of String, Binary or FixedWidthType arrays via ipc.Writer [#11270](https://github.com/apache/arrow/pull/11270), [#11276](https://github.com/apache/arrow/pull/11276)
-* Fixed builds on ARM and s390x architectures [#11299](https://github.com/apache/arrow/pull/11299), [#11305]((https://github.com/apache/arrow/pull/11305)
+* Fixed builds on ARM and s390x architectures [#11299](https://github.com/apache/arrow/pull/11299), [#11305](https://github.com/apache/arrow/pull/11305)
 
 ### Enhancements
 
 * Added [Concatenate](https://github.com/apache/arrow/pull/11128) function for concatenating arrays
-* Implemented [Scalar](https://github.com/apache/arrow/pull/11024) values and `MakeArrayFromScalar` function [#11252]((https://github.com/apache/arrow/pull/11252)
+* Implemented [Scalar](https://github.com/apache/arrow/pull/11024) values and `MakeArrayFromScalar` function [#11252](https://github.com/apache/arrow/pull/11252)
 * Added cgo [optional allocator](https://github.com/apache/arrow/pull/11206) for allocating memory using the C++ memory pool for use with the C Data [import](https://github.com/apache/arrow/pull/11037) and [export](https://github.com/apache/arrow/pull/11220) APIs 
 * Added support for Month, Day, Nano interval type [#11310](https://github.com/apache/arrow/pull/11310)
 * Completed [Encoding](https://github.com/apache/arrow/pull/10716) package for Parquet, added [Metadata](https://github.com/apache/arrow/pull/10951) package.


### PR DESCRIPTION
https://arrow.apache.org/blog/2021/11/04/6.0.0-release/