### PR TITLE
Update affliation for Kun Liu and Raphael Taylor-Davis

### DIFF
--- a/_data/committers.yml
+++ b/_data/committers.yml
@@ -259,7 +259,7 @@
 - name: Kun Liu
   role: Committer
   alias: liukun
-  affiliation: TBD
+  affiliation: Ebay
 - name: Li Jin
   role: Committer
   alias: icexelloss
@@ -295,7 +295,7 @@
 - name: Raphael Taylor-Davies
   role: Committer
   alias: tustvold
-  affiliation: TBD
+  affiliation: InfluxData
 - name: Rémi Dattai
   role: Committer
   alias: rdettai


### PR DESCRIPTION
While looking at https://arrow.apache.org/committers/

I noticed these still said TBD so I filled them in with what I think the affiliation are for @tustvold  and @liukun4515 

