### PR TITLE
ARROW-18418: [WEBSITE] Do not delete /datafusion-python

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
             --exclude '/ballista/' \
             --exclude '/docs/' \
             --exclude '/datafusion/' \
+            --exclude '/datafusion-python/' \
             ../build/ \
             ./
           rsync \


### PR DESCRIPTION
In preparation for publishing the DataFusion Python documentation