### PR TITLE
ARROW-18428: [Website] Enable github issues on arrow-site repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,8 @@ github:
     squash: true
     merge: false
     rebase: false
+  features:
+    issues: true
 
 publish:
   whoami: asf-site


### PR DESCRIPTION
Now we are moving to GitHub issues, it probably makes sense to open issues about the website in its own arrow-site repo, instead of keeping them in the main arrow repo.

See also https://github.com/apache/arrow/issues/14862#issuecomment-1339747345