### PR TITLE
GH-284: Update Apache Arrow website references to Jira

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -69,7 +69,7 @@
           <div class="dropdown-menu" aria-labelledby="navbarDropdownCommunity">
             <a class="dropdown-item" href="{{ site.baseurl }}/community/">Communication</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/developers/contributing.html">Contributing</a>
-            <a class="dropdown-item" href="https://issues.apache.org/jira/browse/ARROW">Issue Tracker</a>
+            <a class="dropdown-item" href="https://github.com/apache/arrow/issues">Issue Tracker</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/committers/">Governance</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/use_cases/">Use Cases</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/powered_by/">Powered By</a>

--- a/arrow.rdf
+++ b/arrow.rdf
@@ -29,7 +29,7 @@
     <asfext:pmc rdf:resource="http://arrow.apache.org" />
     <shortdesc>Apache Arrow is a cross-language development platform for in-memory data.</shortdesc>
     <description>Apache Arrow is a cross-language development platform for in-memory data.</description>
-    <bug-database rdf:resource="https://issues.apache.org/jira/browse/ARROW" />
+    <bug-database rdf:resource="https://github.com/apache/arrow/issues" />
     <mailing-list rdf:resource="http://mail-archives.apache.org/mod_mbox/arrow-dev/" />
     <download-page rdf:resource="http://arrow.apache.org/release/" />
     <programming-language>C</programming-language>
@@ -49,8 +49,8 @@
     <release>
       <Version>
         <name>Apache Arrow</name>
-        <created>2019-01-20</created>
-        <revision>0.12.0</revision>
+        <created>2022-10-31</created>
+        <revision>10.0.0</revision>
       </Version>
     </release>
     <repository>

--- a/community.md
+++ b/community.md
@@ -75,10 +75,9 @@ their own tags (for example,
 ### GitHub issues
 
 We use GitHub issues as a way to ask questions and engage with the Arrow developer
-community but also for maintaining a queue of development work and as the public
-record for work on the project. We use the mailing lists for development discussions,
-so to keep things in a single place, we prefer not to have lengthy discussions on
-GitHub issues.
+community and for maintaining a queue of development work and as the public
+record of work on the project. We use the mailing lists for development discussions,
+where a lengthy discussions is required.
 
 ## Contributing
 

--- a/community.md
+++ b/community.md
@@ -51,7 +51,7 @@ message.
 You may also wish to subscribe to these lists, which capture some activity streams:
 
 <ul>
-  <li> <code>issues@</code> for the creation of JIRA issues {% include mailing_list_links.html list="issues" %} </li>
+  <li> <code>issues@</code> for the creation of GitHub issues {% include mailing_list_links.html list="issues" %} </li>
   <li> <code>commits@</code> for commits to the <a href="https://github.com/apache/arrow">apache/arrow</a> and <a href="https://github.com/apache/arrow-site">apache/arrow-site</a> repositories (typically to <code>master</code> only) {% include mailing_list_links.html list="commits" %} </li>
   <li> <code>builds@</code> for nightly build reports {% include mailing_list_links.html list="builds" %} </li>
 </ul>
@@ -60,7 +60,6 @@ In addition, we have some "firehose" lists, which exist so that development
 activity is captured in email form for archival purposes.
 
 <ul>
-  <li> <code>jira@</code> for all activity on JIRA issues {% include mailing_list_links.html list="jira" %} </li>
   <li> <code>github@</code> for all activity on the GitHub repositories {% include mailing_list_links.html list="github" %} </li>
 </ul>
 
@@ -75,18 +74,14 @@ their own tags (for example,
 
 ### GitHub issues
 
-We support GitHub issues as a lightweight way to ask questions and engage with
-the Arrow developer community.  That said, we use
-[JIRA](https://issues.apache.org/jira/browse/ARROW) for maintaining a queue of
-development work and as the public record for work on the project, and we use
-the mailing lists for development discussions, so to keep things in a single
-place, we prefer not to have lengthy discussions on GitHub issues.
-
-If you know your question is actually a bug report or feature request, we
-encourage you to go straight to JIRA. If you're not sure, feel free to make a
-GitHub issue to ask your question and we can triage/redirect your question
-there.
+We use GitHub issues as a way to ask questions and engage with the Arrow developer
+community but also for maintaining a queue of development work and as the public
+record for work on the project. We use the mailing lists for development discussions,
+so to keep things in a single place, we prefer not to have lengthy discussions on
+GitHub issues.
 
 ## Contributing
 
-As mentioned above, we use [JIRA](https://issues.apache.org/jira/browse/ARROW) for our issue tracker and [GitHub](https://github.com/apache/arrow) for source control. See the [contribution guidelines]({{ site.baseurl }}/docs/developers/contributing.html) for more.
+As mentioned above, we use [GitHub](https://github.com/apache/arrow) for our issue
+tracker and for source control. See the
+[contribution guidelines]({{ site.baseurl }}/docs/developers/contributing.html) for more.

--- a/faq.md
+++ b/faq.md
@@ -148,7 +148,7 @@ the project itself.  See the [contribution guidelines]({{ site.baseurl
 
 #### **Arrow looks great and I'd totally use it if it only did X. When will it be done?**
 
-We use [JIRA](https://issues.apache.org/jira/browse/ARROW) for our issue
+We use [GitHub](https://github.com/apache/arrow) for our issue
 tracker.  Search for an issue that matches your need. If you find one, feel
 free to comment on it and describe your use case--that will help whoever picks
 up the task. If you don't find one, make it.


### PR DESCRIPTION
This PR is part of the work to update the documentation as we are moving from Jira issue tracker to GitHub issues:
https://github.com/apache/arrow/issues/14822

closes #284