### PR TITLE
Add GitHub issue creation notifications to issues@arrow.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,5 +21,8 @@ github:
   features:
     issues: true
 
+notifications:
+  issues_status: issues@arrow.apache.org
+
 publish:
   whoami: asf-site


### PR DESCRIPTION
Now we have issues here, we should probably be consistent and add notifications for new issues to the issues mailing list.

I didn't add the other notification settings, for example I don't think we want commits since we have automated commits here (unless that's only for the master branch?)