### PR TITLE
[Website] Committer expectations and process

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -114,10 +114,9 @@ typical behaviors include:
 * These contributions to the project should be consistent in quality
   and sustained over time, typically on the order of 6 months or more.
 
-* Assistance growing the size and health of the community via constructive and
-  respectful interactions with the rest of the community. Maintaining a
-  professional and diplomatic approach and try to find consensus
-  amongst other community members.
+* Assistance growing the size and health of the community via
+  constructive, respectful, and consensus driven interactions, as
+  described in our [Code of Conduct] and [the Apache Way].
 
 The mechanics of how the process works is [documented here].  If you
 feel you should be offered committer privileges, but have not been,
@@ -126,3 +125,5 @@ dot apache dot org mailing list.
 
 
 [documented here]: https://cwiki.apache.org/confluence/display/ARROW/Inviting+New+Committers+and+PMC+Members
+[Code of Conduct]: https://www.apache.org/foundation/policies/conduct.html
+[the Apache Way]: https://www.apache.org/theapacheway

--- a/committers.md
+++ b/committers.md
@@ -120,8 +120,8 @@ typical behaviors include:
 
 The mechanics of how the process works is [documented here].  If you
 feel you should be offered committer privileges, but have not been,
-you can reach out to one of the PMC members or the private at arrow
-dot apache dot org mailing list.
+you can reach out to one of the PMC members or the `private@arrow.apache.org`
+mailing list.
 
 
 [documented here]: https://cwiki.apache.org/confluence/display/ARROW/Inviting+New+Committers+and+PMC+Members

--- a/committers.md
+++ b/committers.md
@@ -92,13 +92,11 @@ repositories and serve as non-voting project maintainers. See the
 There are many ways to [contribute](https://arrow.apache.org/docs/developers/contributing.html)
 to the Apache Arrow project, including issue reports,
 documentation, tests, and code. Contributors with sustained, high-quality activity
-may be invited to become a committer by the PMC.
-
-Becoming a committer is a recognition of sustained
-contribution to the project, and comes with the privilege of
-committing changes directly in all Arrow github repositories. Becoming
-a committer is also a significant responsibility, and committers are
-expected to use their status and access to improve the Arrow project
+may be invited to become committers by the PMC
+as a recognition of their sustained
+contribution to the project. A committer can commit
+changes directly in all Arrow github repositories, and have the significant responsibility
+of using their status and access to improve the Arrow project
 for the entire community.
 
 When considering to invite someone to be a committer, the PMC looks for

--- a/committers.md
+++ b/committers.md
@@ -113,8 +113,8 @@ typical behaviors include:
   questions, improving usability, reducing technical debt, helping
   with CI, verifying releases, debugging in strange environments, etc.
 
-* Consistent, significant, and sustained contributions in the Arrow
-  community, typically on the order of 6 months or more.
+* These contributions to the project should be consistent in quality
+  and sustained over time, typically on the order of 6 months or more.
 
 * Assistance growing the size and health of the community via constructive and
   respectful interactions with the rest of the community. Maintaining a

--- a/committers.md
+++ b/committers.md
@@ -64,7 +64,7 @@ on important decisions, including releases and inviting committers to join the P
 ### Committers
 
 Contributors who have demonstrated a sustained commitment to the
-project, may be invited by the PMC to become
+project may be invited by the PMC to become
 [committers](https://www.apache.org/foundation/how-it-works.html#committers).
 Committers are authorized to merge code patches to the project's
 repositories and serve as non-voting project maintainers. See the
@@ -89,20 +89,21 @@ repositories and serve as non-voting project maintainers. See the
 
 ### **Becoming a committer**
 
-As described elsewhere, there are many ways we welcome you to
-contribute the Apache Arrow project such as issue reports,
-documentation, tests, and code. Some particularly active contributors
-may also receive an invitation to become a committer.
+There are many ways to [contribute](https://arrow.apache.org/docs/developers/contributing.html)
+to the Apache Arrow project, including issue reports,
+documentation, tests, and code. Contributors with sustained, high-quality activity
+may be invited to become a committer by the PMC.
 
-The PMC regularly adds new committers from the set of active
-contributors. Becoming a committer is a recognition of sustained
+Becoming a committer is a recognition of sustained
 contribution to the project, and comes with the privilege of
 committing changes directly in all Arrow github repositories. Becoming
 a committer is also a significant responsibility, and committers are
 expected to use their status and access to improve the Arrow project
 for the entire community.
 
-Anyone wishing to become a committer can already do all of the things a
+When considering to invite someone to be a committer, the PMC looks for 
+contributors who are doing the work and exercising the judgment expected
+of a committer. After all, any contributor can already do all of the things a
 committer does except for merge a PR. While there is no set list of
 requirements, nor a checklist that entitles one to commit privileges,
 typical behaviors include:

--- a/committers.md
+++ b/committers.md
@@ -87,7 +87,7 @@ repositories and serve as non-voting project maintainers. See the
   {% endfor %}
 </tbody></table>
 
-### **Becoming a committer**
+### Becoming a committer
 
 There are many ways to [contribute](https://arrow.apache.org/docs/developers/contributing.html)
 to the Apache Arrow project, including issue reports,

--- a/committers.md
+++ b/committers.md
@@ -101,26 +101,25 @@ a committer is also a significant responsibility, and committers are
 expected to use their status and access to improve the Arrow project
 for the entire community.
 
-When considering to invite someone to be a committer, the PMC looks for 
+When considering to invite someone to be a committer, the PMC looks for
 contributors who are doing the work and exercising the judgment expected
-of a committer. After all, any contributor can already do all of the things a
+of a committer already. After all, any contributor can do all of the things a
 committer does except for merge a PR. While there is no set list of
 requirements, nor a checklist that entitles one to commit privileges,
 typical behaviors include:
 
-* Consistent, significant, and sustained involvement in the Arrow
+* Contributions beyond pull requests, such as reviewing other pull requests,
+  fixing bugs and documentation, triaging issues, answering community
+  questions, improving usability, reducing technical debt, helping
+  with CI, verifying releases, debugging in strange environments, etc.
+
+* Consistent, significant, and sustained contributions in the Arrow
   community, typically on the order of 6 months or more.
 
-* Help grow the size and health of the community with constructive and
-  respectful interactions with the rest of the community. Maintain a
+* Assistance growing the size and health of the community via constructive and
+  respectful interactions with the rest of the community. Maintaining a
   professional and diplomatic approach and try to find consensus
   amongst other community members.
-
-* Help maintain existing code, review pull requests, fix bugs and
-  documentation, triage issues, answer community questions, improve
-  usability, reduce technical debt, help with CI, verify releases,
-  debug in strange environments, etc.
-
 
 The mechanics of how the process works is [documented here].  If you
 feel you should be offered committer privileges, but have not been,

--- a/committers.md
+++ b/committers.md
@@ -95,7 +95,7 @@ documentation, tests, and code. Contributors with sustained, high-quality activi
 may be invited to become committers by the PMC
 as a recognition of their sustained
 contribution to the project. A committer can commit
-changes directly in all Arrow github repositories, and have the significant responsibility
+changes directly in all Arrow GitHub repositories, and have the significant responsibility
 of using their status and access to improve the Arrow project
 for the entire community.
 

--- a/committers.md
+++ b/committers.md
@@ -63,12 +63,12 @@ on important decisions, including releases and inviting committers to join the P
 
 ### Committers
 
-Contributors who have demonstrated a sustained commitment to the project, not
-only authoring code but also reviewing others' patches and exercising good
-judgment, may be invited by the PMC to become
+Contributors who have demonstrated a sustained commitment to the
+project, may be invited by the PMC to become
 [committers](https://www.apache.org/foundation/how-it-works.html#committers).
-Committers are authorized to merge code patches to the project and serve as
-non-voting project maintainers.
+Committers are authorized to merge code patches to the project's
+repositories and serve as non-voting project maintainers. See the
+"Becoming a committer" section below for more details.
 
 <table class="table table-striped"><thead>
 <tr>
@@ -86,3 +86,45 @@ non-voting project maintainers.
     {% endif %}
   {% endfor %}
 </tbody></table>
+
+### **Becoming a committer**
+
+As described elsewhere, there are many ways we welcome you to
+contribute the Apache Arrow project such as issue reports,
+documentation, tests, and code. Some particularly active contributors
+may also receive an invitation to become a committer.
+
+The PMC regularly adds new committers from the set of active
+contributors. Becoming a committer is a recognition of sustained
+contribution to the project, and comes with the privilege of
+committing changes directly in all Arrow github repositories. Becoming
+a committer is also a significant responsibility, and committers are
+expected to use their status and access to improve the Arrow project
+for the entire community.
+
+Anyone wishing to become a committer can already do all of the things a
+committer does except for merge a PR. While there is no set list of
+requirements, nor a checklist that entitles one to commit privileges,
+typical behaviors include:
+
+* Consistent, significant, and sustained involvement in the Arrow
+  community, typically on the order of 6 months or more.
+
+* Help grow the size and health of the community with constructive and
+  respectful interactions with the rest of the community. Maintain a
+  professional and diplomatic approach and try to find consensus
+  amongst other community members.
+
+* Help maintain existing code, review pull requests, fix bugs and
+  documentation, triage issues, answer community questions, improve
+  usability, reduce technical debt, help with CI, verify releases,
+  debug in strange environments, etc.
+
+
+The mechanics of how the process works is [documented here].  If you
+feel you should be offered committer privileges, but have not been,
+you can reach out to one of the PMC members or the private at arrow
+dot apache dot org mailing list.
+
+
+[documented here]: https://cwiki.apache.org/confluence/display/ARROW/Inviting+New+Committers+and+PMC+Members


### PR DESCRIPTION
**NOTE** This is a work in progress and does not necessarily represent the PMC stance yet. 

# Rationale
It has come to my attention recently that it may not be clear what criteria we use to determine if we should invite someone new to be a committer. 

I would like to add some clarity that our project is open to new contributors, and that if you want to become more deeply involved with the project, here are the kinds of activities that maintainers do.

Also, I of course want to encourage more people to contribute to our project, and I hope this will inspire some to do so

# Changes

Add a "Becoming a committer" section to https://arrow.apache.org/committers/ 

The content partially came from a discussion on the PMC mailing list, and I would like to thank @nealrichardson @westonpace and @kou  for their help so far.  I also took inspiration from the "Becoming a committer" on the Spark website: https://spark.apache.org/committers.html





