### PR TITLE
Minor: minor changes to rust blog post to fix publish job

### DIFF
--- a/_posts/2023-02-14-rust-32.0.0.md
+++ b/_posts/2023-02-14-rust-32.0.0.md
@@ -187,7 +187,7 @@ We would like to thank everyone who has contributed to the arrow-rs repository s
 
 # Join the community
 
-If you are interested in contributing to the Rust subproject in Apache Arrow, we encourage you to try out Arrow on some of your data, and help
-improve the documentation. You can find a list of open issues
+If you are interested in contributing to the Rust subproject in Apache Arrow, we encourage you to try out Arrow on some of your data, help
+improve the documentation, or submit a PR. You can find a list of open issues
 suitable for beginners [here](https://github.com/apache/arrow-rs/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 and the full list [here](https://github.com/apache/arrow-rs/issues).


### PR DESCRIPTION
The publish job did not complete  and thus https://github.com/apache/arrow-site/pull/305 is not yet visible

https://github.com/apache/arrow-site/actions

<img width="1398" alt="Screenshot 2023-02-14 at 10 20 23 AM" src="https://user-images.githubusercontent.com/490673/218780518-423f7b68-fd60-478c-a5a3-8460f5e2ba57.png">

```
https://github.com/apache/arrow-site/actions/runs/4175072450/jobs/7229492372#step:10:63Run git config user.name "$(git log -1 --pretty=format:%an)"
From https://github.com/apache/arrow-site
 * [new branch]              asf-site   -> deploy/asf-site
 * [new branch]              master     -> deploy/master
Switched to a new branch 'asf-site'
branch 'asf-site' set up to track 'deploy/asf-site'.
[asf-site 5e2e8da16ba] Updating built site (build c4fe669417f1d241fdfc16b6ee9876c2fa18fa70)
 44 files changed, 726 insertions(+), 387 deletions(-)
 create mode 100644 blog/2023/02/13/rust-32.0.0/index.html
To https://github.com/apache/arrow-site.git
 ! [rejected]                asf-site -> asf-site (fetch first)
error: failed to push some refs to 'https://github.com/apache/arrow-site.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.

```

This may be because I merged multiple PRs without the previous job completing.

I am making some minor changes to the blog post to see if I can get the next job to deploy.