### PR TITLE
[Website] Change R version from 11.0.0 to 11.0.0.2

### DIFF
--- a/docs/r/news/index.html
+++ b/docs/r/news/index.html
@@ -25,7 +25,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">11.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">11.0.0.2</small>
     </span>
 
     


### PR DESCRIPTION
The docs show 11.0.0 but since the release we've bumped the version to 11.0.0.2.  I haven't run any scripts here, I've just manually edited the HTML; is this OK?