### PR TITLE
GH-31412: [Website] Remove support for triggering GitHub Actions apache/arrow-site website deployment workflow when pushing to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ on:
   push:
     branches:
       - main
-      - master # TODO (ARROW-15988): Remove master branch
   pull_request:
     branches:
       - "*"
@@ -48,7 +47,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
             github.repository == 'apache/arrow-site'
-      - name: Configure for GitHub Pages on push to main or master branch # TODO (ARROW-15988): Remove master branch
+      - name: Configure for GitHub Pages on push to main branch
         run: |
           owner=$(jq --raw-output .repository.owner.login ${GITHUB_EVENT_PATH})
           repository=$(jq --raw-output .repository.name ${GITHUB_EVENT_PATH})


### PR DESCRIPTION
# Overview

As part of apache/arrow#31142 and in response to the [recent rename of the `apache/arrow-site` repository default branch to `main`](https://issues.apache.org/jira/browse/INFRA-24242), this pull request removes support for triggering the website deployment workflow (`.github/workflows/deploy.yml`) on pushes to a branch with the name "master".

# Qualification

To qualify these changes, I verified that:

1. Pushing these changes to the `main` branch of `mathworks/arrow-site` [triggered the `deploy.yml` workflow as expected](https://github.com/mathworks/arrow-site/actions/runs/4296490412/jobs/7488276762).
2. The workflow step "Configure for GitHub Pages on push to main or master branch" has been renamed to "Configure for GitHub Pages on push to main branch"
3. The `deploy.yml` is no longer being triggered when commits are pushed to a branch named "master".

# Future Directions

1. I will follow up with a separate PR to address apache/arrow#20161

# Notes

**Note**: The [CI failures in the Build step](https://github.com/mathworks/arrow-site/actions/runs/4296490412/jobs/7488276762) are unrelated to this change. This is a result of apache/arrow#34379, which is being addressed separately.

Closes apache/arrow#31412.