### PR TITLE
GH-329: [Website] Add a link to the Ruby End-Of-Life (EOL) schedule in the Prerequisites section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ exists in the ASF; all metadata is local to this project.)
 
 ## Prerequisites
 
-With non-EOL-ed [Ruby](https://www.ruby-lang.org/) installed, run the
-following commands to install [Jekyll](https://jekyllrb.com/).
+With a recent version of [Ruby](https://www.ruby-lang.org/) (i.e. one that does not have
+an [End-Of-Life (EOL) status](https://www.ruby-lang.org/en/downloads/branches/)) installed,
+run the following commands to install [Jekyll](https://jekyllrb.com/).
 
 ```shell
 gem install bundler


### PR DESCRIPTION
# Overview

This pull request adds a link to the [Ruby End-Of-Life (EOL) schedule](https://www.ruby-lang.org/en/downloads/branches/) to the [Prerequisites section of the `README.md` for `apache/arrow-site`](https://github.com/apache/arrow-site#prerequisites). It also spells out the acronym EOL as End-Of-Life to avoid any confusion.

# Qualification

N/A
 
# Future Directions

N/A

# Notes

N/A

Closes apache/arrow-site#329