### PR TITLE
[Website] Clean up unecessary skip of `datafusion` and `datafusion-python`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,8 +101,6 @@ jobs:
             --exclude '/.git/' \
             --exclude '/ballista/' \
             --exclude '/docs/' \
-            --exclude '/datafusion/' \
-            --exclude '/datafusion-python/' \
             ../build/ \
             ./
           rsync \


### PR DESCRIPTION
Per @kou 's suggestion https://github.com/apache/arrow-site/pull/336#issuecomment-1478619475

We are now serving datafusion content from the datafusion-repo -- see https://github.com/apache/arrow-datafusion/issues/5500