### PR TITLE
GH-34907: [R] Update versions.json on R site

### DIFF
--- a/docs/r/versions.json
+++ b/docs/r/versions.json
@@ -4,7 +4,7 @@
         "version": "dev/"
     },
     {
-        "name": "11.0.0 (release)",
+        "name": "11.0.0.3 (release)",
         "version": ""
     },
     {


### PR DESCRIPTION
We missed updating this in the 11.0.0.3 release, which caused the versions dropdown to show incorrect information for selection.