### PR TITLE
[Website] Version 12.0.0 blog post

### DIFF
--- a/_posts/2023-04-19-12.0.0-release.md
+++ b/_posts/2023-04-19-12.0.0-release.md
@@ -1,0 +1,79 @@
+---
+layout: post
+title: "Apache Arrow 12.0.0 Release"
+date: "2023-04-19 00:00:00"
+author: pmc
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+
+The Apache Arrow team is pleased to announce the 12.0.0 release. This covers
+over 3 months of development work and includes [**XXX resolved issues**][1]
+from [**YYY distinct contributors**][2]. See the [Install Page](https://arrow.apache.org/install/)
+to learn how to get the libraries for your platform.
+
+The release notes below are not exhaustive and only expose selected highlights
+of the release. Many other bugfixes and improvements have been made: we refer
+you to the [complete changelog][3].
+
+## Community
+
+Since the 11.0.0 release, Wang Mingming, Mustafa Akur and Ruihang Xia
+have been invited to be committers.
+Will Jones have joined the Project Management Committee (PMC).
+
+Thanks for your contributions and participation in the project!
+
+## Columnar Format Notes
+
+## Arrow Flight RPC notes
+
+## C++ notes
+
+## C# notes
+
+## Go notes
+
+## Java notes
+
+## JavaScript notes
+
+## Python notes
+
+
+## R notes
+
+For more on what’s in the 12.0.0 R package, see the [R changelog][4].
+
+## Ruby and C GLib notes
+
+
+## Rust notes
+
+The Rust projects have moved to separate repositories outside the
+main Arrow monorepo. For notes on the latest release of the Rust
+implementation, see the latest [Arrow Rust changelog][5].
+
+[1]: https://github.com/apache/arrow/milestone/51?closed=1
+[2]: {{ site.baseurl }}/release/12.0.0.html#contributors
+[3]: {{ site.baseurl }}/release/12.0.0.html#changelog
+[4]: {{ site.baseurl }}/docs/r/news/
+[5]: https://github.com/apache/arrow-rs/tags


### PR DESCRIPTION
PR to start adding the blog post information for the Release 12.0.0

The 12.0.0 milestone with all the GitHub closed issues can be found here:
https://github.com/apache/arrow/milestone/51?closed=1