### PR TITLE
[Website] Version 12.0.1 blogpost

### DIFF
--- a/_posts/2023-06-13-12.0.1-release.md
+++ b/_posts/2023-06-13-12.0.1-release.md
@@ -40,6 +40,10 @@ you to the [complete changelog][3].
 ## Go notes
 
 
+## Java notes
+
+* Bumped jackson-databind dependency version to avoid CVE-2022-42003. ([GH-35771](https://github.com/apache/arrow/pull/35771))
+
 ## Python notes
 
 

--- a/_posts/2023-06-13-12.0.1-release.md
+++ b/_posts/2023-06-13-12.0.1-release.md
@@ -39,6 +39,10 @@ you to the [complete changelog][3].
 
 ## Go notes
 
+* Fixed builds of the Go Arrow package on 32-bit systems ([GH-34784](https://github.com/apache/arrow/pull/35767))
+* Added `ValueString(int) string` method to `arrow.Array` ([GH-34657](https://github.com/apache/arrow/pull/34986))
+* Fixed ASAN failure when using go1.20+ by using `unsafe.StringData` ([GH-35337](https://github.com/apache/arrow/pull/35338))
+
 
 ## Java notes
 
@@ -46,8 +50,13 @@ you to the [complete changelog][3].
 
 ## Python notes
 
+* Fix `Table.join` respecting the `coalesce_keys=False` option again ([GH-35389](https://github.com/apache/arrow/issues/35389))
+
 
 ## R notes
+
+* Update the version of the date library vendored with Arrow C++ library for compatibility with tzdb 0.4.0 ([GH-35594](https://github.com/apache/arrow/issues/35594), [GH-35612](https://github.com/apache/arrow/issues/35612))
+
 
 
 ## Other modules and languages

--- a/_posts/2023-06-13-12.0.1-release.md
+++ b/_posts/2023-06-13-12.0.1-release.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: "Apache Arrow 12.0.1 Release"
+date: "2023-06-13 00:00:00"
+author: pmc
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+
+The Apache Arrow team is pleased to announce the 12.0.1 release.
+This is mostly a bugfix release that includes [**38 resolved issues**][1]
+from [**12 distinct contributors**][2]. See the Install Page to learn how to
+get the libraries for your platform.
+
+The release notes below are not exhaustive and only expose selected highlights
+of the release. Many other bugfixes and improvements have been made: we refer
+you to the [complete changelog][3].
+
+## C++ notes
+
+
+## Go notes
+
+
+## Python notes
+
+
+## R notes
+
+
+## Other modules and languages
+
+No general changes were made to the other libraries or languages.
+
+
+[1]: https://github.com/apache/arrow/milestone/54?closed=1
+[2]: {{ site.baseurl }}/release/12.0.1.html#contributors
+[3]: {{ site.baseurl }}/release/12.0.1.html#changelog

--- a/_posts/2023-06-13-12.0.1-release.md
+++ b/_posts/2023-06-13-12.0.1-release.md
@@ -35,7 +35,9 @@ of the release. Many other bugfixes and improvements have been made: we refer
 you to the [complete changelog][3].
 
 ## C++ notes
-
+ * Fixed a performance regression when writing data from non-arrow sources (e.g. pandas) ([GH-35498](https://github.com/apache/arrow/pull/35565))
+ * Fixed a "Data size too large" error that could occur when reading valid parquet files ([GH-35423](https://github.com/apache/arrow/pull/35428))
+ * It is now possible to specify field-level metadata in dataset writes ([GH-35730](https://github.com/apache/arrow/pull/35860))
 
 ## Go notes
 

--- a/_posts/2023-06-13-12.0.1-release.md
+++ b/_posts/2023-06-13-12.0.1-release.md
@@ -35,9 +35,11 @@ of the release. Many other bugfixes and improvements have been made: we refer
 you to the [complete changelog][3].
 
 ## C++ notes
+
  * Fixed a performance regression when writing data from non-arrow sources (e.g. pandas) ([GH-35498](https://github.com/apache/arrow/pull/35565))
  * Fixed a "Data size too large" error that could occur when reading valid parquet files ([GH-35423](https://github.com/apache/arrow/pull/35428))
  * It is now possible to specify field-level metadata in dataset writes ([GH-35730](https://github.com/apache/arrow/pull/35860))
+
 
 ## Go notes
 
@@ -50,6 +52,7 @@ you to the [complete changelog][3].
 
 * Bumped jackson-databind dependency version to avoid CVE-2022-42003. ([GH-35771](https://github.com/apache/arrow/pull/35771))
 
+
 ## Python notes
 
 * Fix `Table.join` respecting the `coalesce_keys=False` option again ([GH-35389](https://github.com/apache/arrow/issues/35389))
@@ -58,7 +61,6 @@ you to the [complete changelog][3].
 ## R notes
 
 * Update the version of the date library vendored with Arrow C++ library for compatibility with tzdb 0.4.0 ([GH-35594](https://github.com/apache/arrow/issues/35594), [GH-35612](https://github.com/apache/arrow/issues/35612))
-
 
 
 ## Other modules and languages


### PR DESCRIPTION
PR for blog post information for the Release 12.0.1

The 12.0.1 milestone with all the GitHub closed issues can be found here:
https://github.com/apache/arrow/milestone/54?closed=1

And the published release page: https://arrow.apache.org/release/12.0.1.html
