### PR TITLE
[WEBSITE] Minor: Fix typo on DataFusion 26 blog

### DIFF
--- a/_posts/2023-06-24-datafusion-25.0.0.md
+++ b/_posts/2023-06-24-datafusion-25.0.0.md
@@ -132,7 +132,7 @@ overview talks created:
 
 ### More Streaming, Less Memory
 
-We have made significany progress on the [streaming execution roadmap]
+We have made significant progress on the [streaming execution roadmap]
 such as [unbounded datasources], [streaming group by], sophisticated
 [sort] and [repartitioning] improvements in the optimizer, and support
 for [symmetric hash join] (read more about that in the great [Synnada


### PR DESCRIPTION
Typo in https://github.com/apache/arrow-site/pull/370 -- thanks to @tustvold  for the spot