### PR TITLE
[WEBSITE]: Minor fix blog link on DataFusion 26 blog

### DIFF
--- a/_posts/2023-06-24-datafusion-25.0.0.md
+++ b/_posts/2023-06-24-datafusion-25.0.0.md
@@ -152,7 +152,7 @@ runtime errors].
 [unbounded datasources]: https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html#method.unbounded_output
 [streaming group by]: https://docs.rs/datafusion/latest/datafusion/physical_plan/aggregates/enum.GroupByOrderMode.html
 [symmetric hash join]: https://docs.rs/datafusion/latest/datafusion/physical_plan/joins/struct.SymmetricHashJoinExec.html
-[synnada blog post]: https://github.com/apache/arrow-datafusion/issues/4285
+[synnada blog post]: https://www.synnada.ai/blog/general-purpose-stream-joins-via-pruning-symmetric-hash-joins
 [memory management]: https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/index.html
 [generate runtime errors]: https://github.com/apache/arrow-datafusion/issues/3941
 


### PR DESCRIPTION
@stuartcarnie noticed this link was incorrect, it should point at https://www.synnada.ai/blog/general-purpose-stream-joins-via-pruning-symmetric-hash-joins