### PR TITLE
Update docs.rs link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -45,7 +45,7 @@
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/python">Python</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/r">R</a>
             <a class="dropdown-item" href="https://github.com/apache/arrow/blob/main/ruby/README.md">Ruby</a>
-            <a class="dropdown-item" href="https://docs.rs/crate/arrow/">Rust</a>
+            <a class="dropdown-item" href="https://docs.rs/arrow/latest">Rust</a>
           </div>
         </li>
         <li class="nav-item dropdown">


### PR DESCRIPTION

The link on https://arrow.apache.org/  for the Rust documentation 
![Screenshot 2023-06-28 at 3 39 46 PM](https://github.com/apache/arrow-site/assets/490673/33f6fe69-84ec-4b08-9d43-13ea21c44125)


# Current Behavior
Goes to https://docs.rs/crate/arrow/ a hosted version of the crates.io page:

![Screenshot 2023-06-28 at 3 38 14 PM](https://github.com/apache/arrow-site/assets/490673/4d10df00-16a3-4f49-ba03-125bf9d9d03b)

# Proposed Behavior

Go to the standard rust docs: https://docs.rs/arrow/latest which I think is what I would expect when I click on a documentation link

![Screenshot 2023-06-28 at 3 37 57 PM](https://github.com/apache/arrow-site/assets/490673/b0d02541-a5ad-48b9-86f2-1d1355dcfe70)


