### PR TITLE
Add Subproject dropdown item for nanoarrow

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -59,6 +59,7 @@
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/format/Flight.html">Arrow Flight</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/format/FlightSql.html">Arrow Flight SQL</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/datafusion">DataFusion</a>
+            <a class="dropdown-item" href="{{ site.baseurl }}/nanoarrow">nanoarrow</a>
           </div>
         </li>
         <li class="nav-item dropdown">


### PR DESCRIPTION
This PR adds a link in the "Subprojects" dropdown menu for nanoarrow and links to the nanoarrow documentation ( https://arrow.apache.org/nanoarrow ).

I *think* this is the appropriate place for the link...nanoarrow is not *really* a language binding (since it also has language bindings for things like R that already have an Arrow implementation). I'm happy to link from somewhere else, too.