### PR TITLE
[Website]: Correct committer data for `jakevin`, `avantgardner`, `akurmustafa` and `wayne`

### DIFF
--- a/_data/committers.yml
+++ b/_data/committers.yml
@@ -93,7 +93,7 @@
   affiliation: Workday
 - name: Jie Wen
   role: PMC
-  alias: jackwener
+  alias: jakevin
   affiliation: SelectDB
 - name: Jorge Cardoso Leitao
   role: PMC
@@ -238,7 +238,7 @@
   affiliation: SGH Warsaw School of Economics
 - name: Brent Gardner
   role: Committer
-  alias: avantgardnerio
+  alias: avantgardner
   affiliation: Space and Time
 - name: Brian Hulette
   role: Committer
@@ -342,7 +342,7 @@
   affiliation: Synnada
 - name: Mustafa Akur
   role: Committer
-  alias: mustafasrepo
+  alias: akurmustafa
   affiliation: Synnada
 - name: Paddy Horan
   role: Committer
@@ -386,7 +386,7 @@
   affiliation: Posit
 - name: Ruihang Xia
   role: Committer
-  alias: waynexia
+  alias: wayne
   affiliation: Greptime
 - name: Xudong Wang
   role: Committer


### PR DESCRIPTION
Closes https://github.com/apache/arrow-site/issues/383

# Rationale

The committers page has links to the apache phonebook and thus the alias should be the apache user name (rather than github username): https://arrow.apache.org/committers/

@pitrou  noticed that there were some entries that used the github names instead

# Changes

Correct committer data for `jakevin`, `avantgardner`, `akurmustafa` and `wayne`


Note: I will make a separate PR to add an entry for Gang Wu


cc @waynexia @avantgardnerio @mustafasrepo @jackwener 