### PR TITLE
MINOR: [Website] Fix milestone link for 13.0.0 blogpost

### DIFF
--- a/_posts/2023-08-24-13.0.0-release.md
+++ b/_posts/2023-08-24-13.0.0-release.md
@@ -368,7 +368,7 @@ The Rust projects have moved to separate repositories outside the
 main Arrow monorepo. For notes on the latest release of the Rust
 implementation, see the latest [Arrow Rust changelog][5].
 
-[1]: https://github.com/apache/arrow/milestone/51?closed=1
+[1]: https://github.com/apache/arrow/milestone/53?closed=1
 [2]: {{ site.baseurl }}/release/13.0.0.html#contributors
 [3]: {{ site.baseurl }}/release/13.0.0.html#changelog
 [4]: {{ site.baseurl }}/docs/r/news/


### PR DESCRIPTION
I did forget to update the milestone for the 13.0.0 release.