### PR TITLE
[R] Add missing section to R package changelog

### DIFF
--- a/docs/r/news/index.html
+++ b/docs/r/news/index.html
@@ -87,7 +87,11 @@
     </div>
 
     <div class="section level2">
-<h2 class="pkg-version" data-toc-text="13.0.0" id="arrow-1300">arrow 13.0.0<a class="anchor" aria-label="anchor" href="#arrow-1300"></a></h2>
+<h2 class="pkg-version" data-toc-text="13.0.0" id="arrow-1300">arrow 13.0.0<a class="anchor" aria-label="anchor" href="#arrow-1300"></a></h2><p class="text-muted">CRAN release: 2023-08-30</p>
+<div class="section level3">
+<h3 id="breaking-changes-13-0-0">Breaking changes<a class="anchor" aria-label="anchor" href="#breaking-changes-13-0-0"></a></h3>
+<ul><li>Input objects which inherit only from <code>data.frame</code> and no other classes now have the <code>class</code> attribute dropped, resulting in now always returning tibbles from file reading functions and <code><a href="../reference/table.html">arrow_table()</a></code>, which results in consistency in the type of returned objects. Calling <code><a href="https://rdrr.io/r/base/as.data.frame.html" class="external-link">as.data.frame()</a></code> on Arrow Tabular objects now always returns a <code>data.frame</code> object (<a href="https://github.com/apache/arrow/issues/34775" class="external-link">#34775</a>)</li>
+</ul></div>
 <div class="section level3">
 <h3 id="new-features-13-0-0">New features<a class="anchor" aria-label="anchor" href="#new-features-13-0-0"></a></h3>
 <ul><li>


### PR DESCRIPTION
A [PR to the arrow repo added a missing section to the R package changelog](https://github.com/apache/arrow/pull/37326), but it was after the docs for the release were generated here; this PR adds the missing section.