### PR TITLE
Fix dev-docs workflow

### DIFF
--- a/.github/workflows/devdocs.yml
+++ b/.github/workflows/devdocs.yml
@@ -22,6 +22,9 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   devdocs:
     name: Fetch and upload dev docs

--- a/.github/workflows/devdocs.yml
+++ b/.github/workflows/devdocs.yml
@@ -73,7 +73,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           mkdir -p docs/dev
-          tar -xvzf ../downloads/${{ steps.build.outputs.LATEST }}/test-ubuntu-default-docs/docs.tar.gz -C docs/dev --strip-components=1
+          tar -xvzf ../downloads/${{ steps.build.outputs.LATEST }}/test-ubuntu-*-docs/docs.tar.gz -C docs/dev --strip-components=1
           cp docs/c_glib/index.html docs/dev/c_glib/index.html
           if [ "$(git status --porcelain)" != "" ]; then
             # There are changes to the dev docs


### PR DESCRIPTION
The underlying crossbow job and thus artifact name, changed causing the job to fail. This PR adds a wild card to prepare for future changes in ubuntu version used for the doc as well as restoring function. Tested in my fork https://github.com/apache/arrow-site/actions/runs/6116092199/job/16600761337

fyi @boshek 