### PR TITLE
[Website] Fix wrong example in 2022-10-08-arrow-parquet-encoding-part-2.md

### DIFF
--- a/_posts/2022-10-08-arrow-parquet-encoding-part-2.md
+++ b/_posts/2022-10-08-arrow-parquet-encoding-part-2.md
@@ -264,8 +264,8 @@ For example, a list with offsets `[0, 2, 3, 3]` contains 3 pairs of offsets, `(0
 
 ```python
 0: [child[0], child[1]]
-1: []
-2: [child[2]]
+1: [child[2]]
+2: []
 ```
 
 For the example above with 4 JSON documents, this would be encoded in Arrow as


### PR DESCRIPTION
I was confused when I was reading this: `(0,2)`, `(2,3)`, and `(3,3)`.  I seems to me `child[2]` should be in `(2,3)` not `(3,3)`