### PR TITLE
Update versions.json

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,62 +1,73 @@
 [
     {
         "name": "14.0 (dev)",
-        "version": "dev/"
+        "version": "dev/",
+        "url": "https://arrow.apache.org/docs/dev/"
     },
     {
         "name": "13.0 (stable)",
-        "version": ""
+        "version": "",
+        "url": "https://arrow.apache.org/docs/",
+        "preferred": true
     },
     {
         "name": "12.0",
-        "version": "12.0/"
-    },
-    {
-        "name": "12.0",
-        "version": "12.0/"
+        "version": "12.0/",
+        "url": "https://arrow.apache.org/docs/12.0/"
     },
     {
         "name": "11.0",
-        "version": "11.0/"
+        "version": "11.0/",
+        "url": "https://arrow.apache.org/docs/11.0/"
     },
     {
         "name": "10.0",
-        "version": "10.0/"
+        "version": "10.0/",
+        "url": "https://arrow.apache.org/docs/10.0/"
     },
     {
         "name": "9.0",
-        "version": "9.0/"
+        "version": "9.0/",
+        "url": "https://arrow.apache.org/docs/9.0/"
     },
     {
         "name": "8.0",
-        "version": "8.0/"
+        "version": "8.0/",
+        "url": "https://arrow.apache.org/docs/8.0/"
     },
     {
         "name": "7.0",
-        "version": "7.0/"
+        "version": "7.0/",
+        "url": "https://arrow.apache.org/docs/7.0/"
     },
     {
         "name": "6.0",
-        "version": "6.0/"
+        "version": "6.0/",
+        "url": "https://arrow.apache.org/docs/6.0/"
     },
     {
         "name": "5.0",
-        "version": "5.0/"
+        "version": "5.0/",
+        "url": "https://arrow.apache.org/docs/5.0/"
     },
     {
         "name": "4.0",
-        "version": "4.0/"
+        "version": "4.0/",
+        "url": "https://arrow.apache.org/docs/4.0/"
     },
     {
         "name": "3.0",
-        "version": "3.0/"
+        "version": "3.0/",
+        "url": "https://arrow.apache.org/docs/3.0/"
     },
     {
         "name": "2.0",
-        "version": "2.0/"
+        "version": "2.0/",
+        "url": "https://arrow.apache.org/docs/2.0/"
     },
     {
         "name": "1.0",
-        "version": "1.0/"
+        "version": "1.0/",
+        "url": "https://arrow.apache.org/docs/dev/"
     }
 ]

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -68,6 +68,6 @@
     {
         "name": "1.0",
         "version": "1.0/",
-        "url": "https://arrow.apache.org/docs/dev/"
+        "url": "https://arrow.apache.org/docs/1.0/"
     }
 ]


### PR DESCRIPTION
Pydata sphinx theme is currently [pinned to version `0.8`](https://github.com/apache/arrow/blob/7b14b2b2712bc483cd7d14bbc6c38e26d27074ac/docs/requirements.txt#L8) . The PR that updates the theme is ready to be merged: https://github.com/apache/arrow/pull/36591. Before we can do that we need to update the `versions.json` file as the new theme needs extra data to construct a version switcher and a versions warning.

This change should not affect the existing documentation.

@jorisvandenbossche 