### PR TITLE
GH-25271: Update Apache Description Of A Project (DOAP) File

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -19,7 +19,7 @@ current:
   number: '13.0.0'
   pinned_number: '13.0.*'
   major_number: '13'
-  date: '23 August 2023'
+  date: 2023-08-23
   git-tag: 'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0'
   github-tag-link: 'https://github.com/apache/arrow/releases/tag/apache-arrow-13.0.0'
   release-notes: 'https://arrow.apache.org/release/13.0.0.html'

--- a/arrow.rdf
+++ b/arrow.rdf
@@ -23,36 +23,35 @@
 -->
   <Project rdf:about="https://arrow.apache.org">
     <created>2016-02-17</created>
-    <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
-    <name>Apache arrow</name>
-    <homepage rdf:resource="http://arrow.apache.org/" />
-    <asfext:pmc rdf:resource="http://arrow.apache.org" />
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Arrow</name>
+    <homepage rdf:resource="https://arrow.apache.org" />
+    <asfext:pmc rdf:resource="https://arrow.apache.org" />
     <shortdesc>Apache Arrow is a cross-language development platform for in-memory data.</shortdesc>
-    <description>Apache Arrow is a cross-language development platform for in-memory data.</description>
+    <description>Apache Arrow defines a language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware like CPUs and GPUs. The Arrow memory format also supports zero-copy reads for lightning-fast data access without serialization overhead.
+
+Arrow's libraries implement the format and provide building blocks for a range of use cases, including high performance analytics. Many popular projects use Arrow to ship columnar data efficiently or as the basis for analytic engines.
+
+Libraries are available for C, C++, C#, Go, Java, JavaScript, Julia, MATLAB, Python, R, Ruby, and Rust. 
+
+Apache Arrow is software created by and for the developer community. We are dedicated to open, kind communication and consensus decision making. Our committers come from a range of organizations and backgrounds, and we welcome all to participate with us.</description>
     <bug-database rdf:resource="https://github.com/apache/arrow/issues" />
     <mailing-list rdf:resource="http://mail-archives.apache.org/mod_mbox/arrow-dev/" />
     <download-page rdf:resource="http://arrow.apache.org/release/" />
     <programming-language>C</programming-language>
     <programming-language>C++</programming-language>
-    <programming-language>C#</programming-language>
     <programming-language>Go</programming-language>
     <programming-language>Java</programming-language>
-    <programming-language>JavaScript</programming-language>
-    <programming-language>Julia</programming-language>
-    <programming-language>MATLAB</programming-language>
     <programming-language>Python</programming-language>
     <programming-language>R</programming-language>
     <programming-language>Ruby</programming-language>
     <programming-language>Rust</programming-language>
-    <category rdf:resource="http://projects.apache.org/category/library" />
-    <category rdf:resource="http://projects.apache.org/category/big-data" />
-    <release>
-      <Version>
-        <name>Apache Arrow</name>
-        <created>2022-10-31</created>
-        <revision>10.0.0</revision>
-      </Version>
-    </release>
+    <category rdf:resource="https://projects.apache.org/category/big-data" />
+    <category rdf:resource="https://projects.apache.org/category/database" />
+    <category rdf:resource="https://projects.apache.org/category/data-engineering" />
+    <category rdf:resource="https://projects.apache.org/category/library" />
+    <category rdf:resource="https://projects.apache.org/category/network-client" />
+    <category rdf:resource="https://projects.apache.org/category/network-server" />
     <repository>
       <GitRepository>
         <location rdf:resource="https://github.com/apache/arrow.git"/>
@@ -61,3 +60,4 @@
     </repository>
   </Project>
 </rdf:RDF>
+

--- a/arrow.rdf
+++ b/arrow.rdf
@@ -1,3 +1,5 @@
+---
+---
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl"?>
 <rdf:RDF xml:lang="en"
@@ -32,7 +34,7 @@
 
 Arrow's libraries implement the format and provide building blocks for a range of use cases, including high performance analytics. Many popular projects use Arrow to ship columnar data efficiently or as the basis for analytic engines.
 
-Libraries are available for C, C++, C#, Go, Java, JavaScript, Julia, MATLAB, Python, R, Ruby, and Rust. 
+Libraries are available for C, C++, C#, Go, Java, JavaScript, Julia, MATLAB, Python, R, Ruby, and Rust.
 
 Apache Arrow is software created by and for the developer community. We are dedicated to open, kind communication and consensus decision making. Our committers come from a range of organizations and backgrounds, and we welcome all to participate with us.</description>
     <bug-database rdf:resource="https://github.com/apache/arrow/issues" />
@@ -56,6 +58,13 @@ Apache Arrow is software created by and for the developer community. We are dedi
     <category rdf:resource="https://projects.apache.org/category/library" />
     <category rdf:resource="https://projects.apache.org/category/network-client" />
     <category rdf:resource="https://projects.apache.org/category/network-server" />
+    <release>
+      <Version>
+        <name>Apache Arrow</name>
+        <created>{{ site.data.versions.current.date }}</created>
+        <revision>{{ site.data.versions.current.number }}</revision>
+      </Version>
+    </release>
     <repository>
       <GitRepository>
         <location rdf:resource="https://github.com/apache/arrow.git"/>
@@ -64,4 +73,3 @@ Apache Arrow is software created by and for the developer community. We are dedi
     </repository>
   </Project>
 </rdf:RDF>
-

--- a/arrow.rdf
+++ b/arrow.rdf
@@ -61,6 +61,7 @@ Apache Arrow is software created by and for the developer community. We are dedi
     <release>
       <Version>
         <name>Apache Arrow</name>
+        <!-- Release is filled in by Jekyll from contents of _data/versions.yml -->
         <created>{{ site.data.versions.current.date }}</created>
         <revision>{{ site.data.versions.current.number }}</revision>
       </Version>

--- a/arrow.rdf
+++ b/arrow.rdf
@@ -40,8 +40,12 @@ Apache Arrow is software created by and for the developer community. We are dedi
     <download-page rdf:resource="http://arrow.apache.org/release/" />
     <programming-language>C</programming-language>
     <programming-language>C++</programming-language>
+    <programming-language>C#</programming-language>
     <programming-language>Go</programming-language>
     <programming-language>Java</programming-language>
+    <programming-language>JavaScript</programming-language>
+    <programming-language>Julia</programming-language>
+    <programming-language>MATLAB</programming-language>
     <programming-language>Python</programming-language>
     <programming-language>R</programming-language>
     <programming-language>Ruby</programming-language>


### PR DESCRIPTION
### Rationale for this change

The Apache Community Development committee (ComDev) maintains a website [projects.apache.org](http://projects.apache.org/) which lists all ASF projects, and some basic details about them. These details are derived from DOAP (Description Of A Project) file that is maintained by each PMC.

### What changes are included in this PR?

Update the DOAP file for Arrow, which (in theory) drives the content of https://projects.apache.org/project.html?arrow, based on the output of the form at https://projects.apache.org/create.html. 

I have already updated [projects.xml](https://svn.apache.org/repos/asf/comdev/projects.apache.org/trunk/data/projects.xml) as described on https://projects.apache.org/create.html. See  https://github.com/apache/arrow/issues/25271#issuecomment-1735477349 for more details

### Are these changes tested?

N/A
### Are there any user-facing changes?
No
* Closes: https://github.com/apache/arrow/issues/25271