### PR TITLE
MINOR: Fix links in 14.0.1 blog post

### DIFF
--- a/_posts/2023-11-09-14.0.1-release.md
+++ b/_posts/2023-11-09-14.0.1-release.md
@@ -35,7 +35,7 @@ to PyArrow 14.0.1 or later. Binary packages are available on PyPI and conda-forg
 
 If it is not possible to upgrade, we provide a separate package `pyarrow-hotfix`
 that disables the vulnerability on older PyArrow versions.
-See https://pypi.org/project/pyarrow-hotfix/ for instructions.
+See [usage instructions][1].
 
 ## Vulnerability description
 
@@ -46,5 +46,7 @@ if it reads Arrow IPC, Feather or Parquet data from untrusted sources
 
 This vulnerability only affects PyArrow, not other Apache Arrow implementations or bindings.
 
-Reference:
-https://www.cve.org/CVERecord?id=CVE-2023-47248
+CVE Reference can be found on [this link][2].
+
+[1]: https://pypi.org/project/pyarrow-hotfix/
+[2]: https://www.cve.org/CVERecord?id=CVE-2023-47248


### PR DESCRIPTION
Currently links appear as plain text. Fix them to be proper links.