### PR TITLE
[Website] Fix broken link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -70,7 +70,7 @@
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownCommunity">
             <a class="dropdown-item" href="{{ site.baseurl }}/community/">Communication</a>
-            <a class="dropdown-item" href="{{ site.baseurl }}/docs/developers/contributing.html">Contributing</a>
+            <a class="dropdown-item" href="{{ site.baseurl }}/docs/developers/overview.html">Contributing</a>
             <a class="dropdown-item" href="https://github.com/apache/arrow/issues">Issue Tracker</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/committers/">Governance</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/use_cases/">Use Cases</a>


### PR DESCRIPTION
According to the [issue](https://github.com/apache/arrow/issues/38851), it can be confirmed that the link to `Community` -> `Contributing` is broken on the main page of the Arrow website.

If the correct link would be to the [Contributing Overview](https://arrow.apache.org/docs/developers/overview.html), it seems that it needs to be updated accordingly.