### PR TITLE
[Website]: Update instructions with workaround for new ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Then add/commit/push from the `asf-site/` git checkout.
 If you don't wish to change or install `ruby` and `nodejs` locally, you can use docker to build and preview the site with a command like:
 
 ```shell
-docker run -v `pwd`:/arrow-site -p 4000:4000 -it ruby bash
+docker run -v `pwd`:/arrow-site -p 4000:4000 -it ruby:3.2.2-slim-bullseye bash
 cd arrow-site
 apt-get update
 apt-get install -y npm

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ bundle install
 bundle exec rake HOST=0.0.0.0
 ```
 
-Then open http://locahost:4000 locally
+Then open http://localhost:4000 locally


### PR DESCRIPTION
Update readme with a workaround described on https://github.com/apache/arrow-site/issues/447

Pinning the ruby version means the site builds for me now locally