### PR TITLE
[Website]: Update to Jekyl `4.3.3`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@
 source "https://rubygems.org"
 ruby RUBY_VERSION
 
-gem "jekyll", "4.2.0"
+gem "jekyll", "4.3.3"
 gem "rake"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "webrick"

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ bundle install
 bundle exec rake HOST=0.0.0.0
 ```
 
-Then open http://locahost:4000 locally
+Then open http://localhost:4000 locally

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ bundle install
 bundle exec rake HOST=0.0.0.0
 ```
 
-Then open http://localhost:4000 locally
+Then open http://locahost:4000 locally


### PR DESCRIPTION
As suggested by @kou  in https://github.com/apache/arrow-site/pull/448#issuecomment-1878591082 let's use the latest Jekyll so the docs build with the latest ruby version

Note that @bkmgit has another PR that updates all dependencies in https://github.com/apache/arrow-site/pull/449