### PR TITLE
Install required node modules and ruby gems

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,15 +30,14 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v4
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
+      - name: Install Ruby and nodejs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y npm ruby ruby-dev
+          npm install
+          sudo gem install bundler
+          bundle config set --local path vendor/bundle
+          bundle install
       - name: Configure for production
         run: |
           echo "JEKYLL_BASE_URL=" >> ${GITHUB_ENV}


### PR DESCRIPTION
Need newer versions than in existing images

As compared to https://github.com/apache/arrow-site/pull/453 baseurl is not set. Only merge one of the two, I think it is preferable to have baseurl. Site can be previewed at https://bkmgit.github.io/arrow-site/ from preview generated at https://github.com/bkmgit/arrow-site/pull/3