### PR TITLE
Add Powered By note for pantab

### DIFF
--- a/powered_by.md
+++ b/powered_by.md
@@ -154,6 +154,10 @@ short description of your use case.
 * **[pandas][12]:** data analysis toolkit for Python programmers. pandas
   supports reading and writing Parquet files using pyarrow. Several pandas
   core developers are also contributors to Apache Arrow.
+* **[pantab][52]:** Allows high performance read/writes of popular dataframe libraries
+  like pandas, polars pyarrow, etc... to/from Tableau's Hyper database. pantab uses nanoarrow
+  and the Arrow PyCapsule interface to make that exchange process seamless.
+  core developers are also contributors to Apache Arrow.
 * **[Parseable][51]:** Log analytics platform built for scale and usability. Ingest logs from anywhere and unify logs with Parseable. Parseable uses Arrow as the intermediary, in-memory data format for log data ingestion.
 * **[Perspective][23]:** Perspective is a streaming data visualization engine in JavaScript for building real-time & user-configurable analytics entirely in the browser.
 * **[Petastorm][28]:** Petastorm enables single machine or distributed training
@@ -262,3 +266,4 @@ short description of your use case.
 [49]: https://kaskada.io
 [50]: https://openobserve.ai
 [51]: https://parseable.io
+[52]: https://github.com/innobi/pantab


### PR DESCRIPTION
Hi - I built pantab about 6 years ago to write pandas DataFrames to a proprietary database owned by Tableau called Hyper. Over time hacking into pandas internals proved to be difficult, and I very recently swapped over to using nanoarrow and the Arrow PyCapsule interface with great results.

No hard feelings if there is not an appetite for this PR, but I figured I'd put it out there to celebrate the awesomeness of Arrow