### PR TITLE
Remove no longer needed build/docs/ sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,10 +103,6 @@ jobs:
             --exclude '/docs/' \
             ../build/ \
             ./
-          rsync \
-            -a \
-            ../build/docs/ \
-            docs/
           touch .nojekyll
           if [ "$(git status --porcelain)" != "" ]; then
             # There are changes to the built site


### PR DESCRIPTION
fix #488

All docs/ contents are built by Sphinx in apache/arrow after #485.
