### PR TITLE
[Website] Add `.htaccess` to redirect  https://arrow.apache.org/datafusion to https://datafusion.apache.org/

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# redirect all datafusion URLs to new top level website
+Redirect permanent /datafusion https://datafusion.apache.org

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -58,7 +58,7 @@
             <a class="dropdown-item" href="{{ site.baseurl }}/adbc">ADBC</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/format/Flight.html">Arrow Flight</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/format/FlightSql.html">Arrow Flight SQL</a>
-            <a class="dropdown-item" href="{{ site.baseurl }}/datafusion">DataFusion</a>
+            <a class="dropdown-item" href="https://datafusion.apache.org">DataFusion</a>
             <a class="dropdown-item" href="{{ site.baseurl }}/nanoarrow">nanoarrow</a>
           </div>
         </li>


### PR DESCRIPTION
Closes https://github.com/apache/datafusion/issues/10194
Closes https://github.com/apache/arrow-site/pull/502

Per @kou 's suggestion in https://github.com/apache/arrow-site/pull/502#issuecomment-2073432866, this PR adds a `.htaccess` file with a redirect from all `www.apache.org/datafusion` urls to `datadfusion.apache.org` urls (I think)

Documentaiton on these files is here: https://infra.apache.org/project-site.html

I don't really know how to test this other than "in production"