### PR TITLE
[Website]: Copy .htaccess to deploy site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,7 @@ jobs:
           export JEKYLL_EXTRA_CONFIG=_extra_config.yml
           bundle exec rake generate
           cp -a .asf.yaml ../build/
+          cp -a .htaccess ../build/
       - name: Deploy
         run: |
           git config user.name "$(git log -1 --pretty=format:%an)"


### PR DESCRIPTION
Follow on to https://github.com/apache/arrow-site/pull/505 to actually copy the .htaccess file to the deployment site. Thanks to @kou  for noticing this https://github.com/apache/arrow-site/pull/505#issuecomment-2076086096