### PR TITLE
[Website]: Redirect old DataFusion CLI URL

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,3 +15,6 @@
 
 # redirect all datafusion URLs to new top level website
 Redirect permanent /datafusion https://datafusion.apache.org
+
+# redirect old URL https://github.com/apache/datafusion/issues/10124
+Redirect permanent /datafusion/user-guide/cli.html https://datafusion.apache.org/user-guide/cli/index.html


### PR DESCRIPTION
Closes https://github.com/apache/datafusion/issues/10124

# Rationale
See https://github.com/apache/datafusion/issues/10124 -- basically we moved a URL that is bookmarked / comes up in google search. We need to redirect to the new location

# Changes
Use the `.htaccess` process added in https://github.com/apache/arrow-site/pull/505 https://github.com/apache/arrow-site/pull/506 with @kou  to redirect to the new location