### PR TITLE
[Website] Remove breaking change from C++ section

### DIFF
--- a/_posts/2024-04-20-16.0.0-release.md
+++ b/_posts/2024-04-20-16.0.0-release.md
@@ -79,10 +79,6 @@ and issues connected to the `RecordBatch` conversion are included in this releas
 [GH-40866](https://github.com/apache/arrow/issues/40866)) which means `RecordBatch` can now be
 converted to a column or row-major two-dimensional structure.
 
-## Breaking Changes
-
-- `Function::is_impure` has been renamed to `is_pure` ([GH-40607](https://github.com/apache/arrow/issues/40607)).
-
 ## Compute
 
 ### Bug Fixes


### PR DESCRIPTION
I mistakenly left this bit in in the PR but this change is not what we'd consider a breaking change, see discussion in https://github.com/apache/arrow/issues/40607.