### PR TITLE
Fix update of dev docs (test-ubuntu-*-docs -> test-debian-*-docs build change)

### DIFF
--- a/.github/workflows/devdocs.yml
+++ b/.github/workflows/devdocs.yml
@@ -76,7 +76,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           mkdir -p docs/dev
-          tar -xvzf ../downloads/${{ steps.build.outputs.LATEST }}/test-ubuntu-*-docs/docs.tar.gz -C docs/dev --strip-components=1
+          tar -xvzf ../downloads/${{ steps.build.outputs.LATEST }}/test-debian-*-docs/docs.tar.gz -C docs/dev --strip-components=1
           cp docs/c_glib/index.html docs/dev/c_glib/index.html
           if [ "$(git status --porcelain)" != "" ]; then
             # There are changes to the dev docs


### PR DESCRIPTION
The doc build was changed in https://github.com/apache/arrow/pull/41455, we need a change here accordingly to ensure to keep updating the dev docs from that crossbow build.