### PR TITLE
[Website] Add .htaccess redirect for datafusion-python

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,3 +18,6 @@ Redirect permanent /datafusion/user-guide/cli.html https://datafusion.apache.org
 
 # redirect all datafusion URLs to new top level website
 Redirect permanent /datafusion https://datafusion.apache.org
+
+# redirect all datafusion-python URLs to new website
+Redirect permanent /datafusion-python https://datafusion.apache.org/python


### PR DESCRIPTION
Closes #528 

This PR adds a line to  `.htaccess` file which will should redirect all arrow.apache.org/datafusion-python URLs to datafusion.apache.org/python.

This applies the same change as used for the top level `datafusion` https://github.com/apache/arrow-site/pull/505

