### PR TITLE
Add Joel Lubinitsky to Arrow Committers

### DIFF
--- a/_data/committers.yml
+++ b/_data/committers.yml
@@ -344,6 +344,10 @@
   role: Committer
   alias: jiayuliu
   affiliation: Airbnb Inc.
+- name: Joel Lubinitsky
+  role: Committer
+  alias: joellubi
+  affiliation: Voltron Data
 - name: Kazuaki Ishizaki
   role: Committer
   alias: kiszk


### PR DESCRIPTION
Adding missing committer entry with new affiliation.