### PR TITLE
Website: Add blog post for 17.0.0

### DIFF
--- a/_posts/2024-07-16-17.0.0-release.md
+++ b/_posts/2024-07-16-17.0.0-release.md
@@ -61,6 +61,10 @@ Thanks for your contributions and participation in the project!
 
 ## C++ notes
 
+For C++ notes refer to the full changelog.
+
+### Highlights
+
 - Half-float values can now be parsed and formatted correctly (GH-41089).
 - Record batches can now be converted to row-major tensors, not only column-major (GH-40866).
 - The CSV writer is now able to write large string arrays that are larger than
@@ -185,14 +189,14 @@ Thanks for your contributions and participation in the project!
 
 ## Python notes
 
-Compatibility notes:
+### Compatibility notes:
 * To ensure Python 3.13 compatibility, _Py_IsFinalizing has been replaced with a public API (GH-41475).
 * The C Data Interface now supports CUDA devices (GH-40384).
 
-New features:
+### New features:
 * Added support for Emscripten via Pyodide (GH-41910).
 
-Other improvements:
+### Other improvements:
 * The ParquetWriter added the store_decimal_as_integer option (GH-42168).
 * The Float16 logical type is supported in Parquet (GH-42016).
 * Exposed bit_width and byte_width to extension types (GH-41389).
@@ -200,7 +204,7 @@ Other improvements:
 * The PyCapsule interface now exposes the device interface (GH-38325).
 * Various PyArrow APIs have been updated to work with non-CPU architectures gracefully. (GH-42112, GH-41664, GH-41662, 
 
-Relevant bug fixes:
+### Relevant bug fixes:
 * Fixed Numpy 2.0 compatibility issues (GH-42170, GH-41924).
 * Fixed sporadic as_of join failures (GH-41149).
 * Fixed a bug in RecordBatch.filter() when passing a ChunkedArray, which would cause a segfault (GH-38770).


### PR DESCRIPTION
Release blog post for 17.0.0.

Release notes are here: https://arrow.apache.org/release/17.0.0.html
Issues on the milestone are here: https://github.com/apache/arrow/milestone/62?closed=1