### PR TITLE
[Website] Update R docs for version 17.0.0.1

### DIFF
--- a/docs/r/404.html
+++ b/docs/r/404.html
@@ -48,7 +48,7 @@
     <a class="navbar-brand me-2" href="https://arrow.apache.org/docs/r/index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/PACKAGING.html
+++ b/docs/r/PACKAGING.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/STYLE.html
+++ b/docs/r/STYLE.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/arrow.html
+++ b/docs/r/articles/arrow.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/data_objects.html
+++ b/docs/r/articles/data_objects.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/data_types.html
+++ b/docs/r/articles/data_types.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/data_wrangling.html
+++ b/docs/r/articles/data_wrangling.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/dataset.html
+++ b/docs/r/articles/dataset.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developers/data_object_layout.html
+++ b/docs/r/articles/developers/data_object_layout.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developers/debugging.html
+++ b/docs/r/articles/developers/debugging.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developers/docker.html
+++ b/docs/r/articles/developers/docker.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developers/install_details.html
+++ b/docs/r/articles/developers/install_details.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developers/setup.html
+++ b/docs/r/articles/developers/setup.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developers/workflow.html
+++ b/docs/r/articles/developers/workflow.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/developing.html
+++ b/docs/r/articles/developing.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/flight.html
+++ b/docs/r/articles/flight.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/fs.html
+++ b/docs/r/articles/fs.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/index.html
+++ b/docs/r/articles/index.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/install.html
+++ b/docs/r/articles/install.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/install_nightly.html
+++ b/docs/r/articles/install_nightly.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/metadata.html
+++ b/docs/r/articles/metadata.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/python.html
+++ b/docs/r/articles/python.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/articles/read_write.html
+++ b/docs/r/articles/read_write.html
@@ -52,7 +52,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/authors.html
+++ b/docs/r/authors.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/index.html
+++ b/docs/r/index.html
@@ -50,7 +50,7 @@
     <a class="navbar-brand me-2" href="index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/news/index.html
+++ b/docs/r/news/index.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 
@@ -73,13 +73,29 @@
     </div>
 
     <div class="section level2">
-<h2 class="pkg-version" data-toc-text="17.0.0" id="arrow-1700">arrow 17.0.0<a class="anchor" aria-label="anchor" href="#arrow-1700"></a></h2>
+<h2 class="pkg-version" data-toc-text="17.0.0.1" id="arrow-17001">arrow 17.0.0.1<a class="anchor" aria-label="anchor" href="#arrow-17001"></a></h2><p class="text-muted">CRAN release: 2024-08-21</p>
+<ul><li>Resolve an issue with CRAN’s M1 builders and the AWS SDK dependency build process.</li>
+</ul></div>
+    <div class="section level2">
+<h2 class="pkg-version" data-toc-text="17.0.0" id="arrow-1700">arrow 17.0.0<a class="anchor" aria-label="anchor" href="#arrow-1700"></a></h2><p class="text-muted">CRAN release: 2024-08-17</p>
+<div class="section level3">
+<h3 id="new-features-17-0-0">New features<a class="anchor" aria-label="anchor" href="#new-features-17-0-0"></a></h3>
 <ul><li>R functions that users write that use functions that Arrow supports in dataset queries now can be used in queries too. Previously, only functions that used arithmetic operators worked. For example, <code>time_hours &lt;- function(mins) mins / 60</code> worked, but <code>time_hours_rounded &lt;- function(mins) round(mins / 60)</code> did not; now both work. These are automatic translations rather than true user-defined functions (UDFs); for UDFs, see <code><a href="../reference/register_scalar_function.html">register_scalar_function()</a></code>. (<a href="https://github.com/apache/arrow/issues/41223" class="external-link">#41223</a>)</li>
+<li>
+<code><a href="https://dplyr.tidyverse.org/reference/mutate.html" class="external-link">mutate()</a></code> expressions can now include aggregations, such as <code>x - mean(x)</code>. (<a href="https://github.com/apache/arrow/issues/41350" class="external-link">#41350</a>)</li>
 <li>
 <code><a href="https://dplyr.tidyverse.org/reference/summarise.html" class="external-link">summarize()</a></code> supports more complex expressions, and correctly handles cases where column names are reused in expressions.</li>
 <li>The <code>na_matches</code> argument to the <code>dplyr::*_join()</code> functions is now supported. This argument controls whether <code>NA</code> values are considered equal when joining. (<a href="https://github.com/apache/arrow/issues/41358" class="external-link">#41358</a>)</li>
 <li>R metadata, stored in the Arrow schema to support round-tripping data between R and Arrow/Parquet, is now serialized and deserialized more strictly. This makes it safer to load data from files from unknown sources into R data.frames. (<a href="https://github.com/apache/arrow/issues/41969" class="external-link">#41969</a>)</li>
 </ul></div>
+<div class="section level3">
+<h3 id="minor-improvements-and-fixes-17-0-0">Minor improvements and fixes<a class="anchor" aria-label="anchor" href="#minor-improvements-and-fixes-17-0-0"></a></h3>
+<ul><li>Turn on the S3 and ZSTD features by default for macOS. (<a href="https://github.com/apache/arrow/issues/42210" class="external-link">#42210</a>)</li>
+<li>Fix bindings in Math group generics. (<a href="https://github.com/apache/arrow/issues/43162" class="external-link">#43162</a>)</li>
+<li>Fix a bug in our implementation of <code>pull</code> on grouped datasets, it now returns the expected column. (<a href="https://github.com/apache/arrow/issues/43172" class="external-link">#43172</a>)</li>
+<li>The minimum version of the Arrow C++ library the Arrow R package can be built with has been bumped to 15.0.0 (<a href="https://github.com/apache/arrow/issues/42241" class="external-link">#42241</a>)</li>
+</ul></div>
+</div>
     <div class="section level2">
 <h2 class="pkg-version" data-toc-text="16.1.0" id="arrow-1610">arrow 16.1.0<a class="anchor" aria-label="anchor" href="#arrow-1610"></a></h2><p class="text-muted">CRAN release: 2024-05-25</p>
 <div class="section level3">

--- a/docs/r/reference/ArrayData.html
+++ b/docs/r/reference/ArrayData.html
@@ -24,7 +24,7 @@ inside an arrow::Array."><meta property="og:image" content="https://arrow.apache
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Buffer-class.html
+++ b/docs/r/reference/Buffer-class.html
@@ -24,7 +24,7 @@ contiguous memory with a particular size."><meta property="og:image" content="ht
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ChunkedArray-class.html
+++ b/docs/r/reference/ChunkedArray-class.html
@@ -26,7 +26,7 @@ may be grouped together in a Table."><meta property="og:image" content="https://
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Codec.html
+++ b/docs/r/reference/Codec.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/CsvFileFormat.html
+++ b/docs/r/reference/CsvFileFormat.html
@@ -24,7 +24,7 @@ read and parse the files included in a CSV Dataset."><meta property="og:image" c
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/CsvReadOptions.html
+++ b/docs/r/reference/CsvReadOptions.html
@@ -28,7 +28,7 @@ read_json_arrow(), respectively."><meta property="og:image" content="https://arr
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/CsvTableReader.html
+++ b/docs/r/reference/CsvTableReader.html
@@ -26,7 +26,7 @@ read_json_arrow(), respectively."><meta property="og:image" content="https://arr
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/DataType-class.html
+++ b/docs/r/reference/DataType-class.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Dataset.html
+++ b/docs/r/reference/Dataset.html
@@ -34,7 +34,7 @@ DatasetFactory is used to provide finer control over the creation of Datasets.">
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/DictionaryType.html
+++ b/docs/r/reference/DictionaryType.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Expression.html
+++ b/docs/r/reference/Expression.html
@@ -46,7 +46,7 @@ are preserved and not unnecessarily upcast, which may be expensive."><meta prope
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ExtensionArray.html
+++ b/docs/r/reference/ExtensionArray.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ExtensionType.html
+++ b/docs/r/reference/ExtensionType.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FeatherReader.html
+++ b/docs/r/reference/FeatherReader.html
@@ -26,7 +26,7 @@ make an arrow::Table. See its usage in read_feather()."><meta property="og:image
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Field-class.html
+++ b/docs/r/reference/Field-class.html
@@ -26,7 +26,7 @@ Schemas."><meta property="og:image" content="https://arrow.apache.org/img/arrow-
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Field.html
+++ b/docs/r/reference/Field.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FileFormat.html
+++ b/docs/r/reference/FileFormat.html
@@ -26,7 +26,7 @@ file formats (ParquetFileFormat and IpcFileFormat)."><meta property="og:image" c
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FileInfo.html
+++ b/docs/r/reference/FileInfo.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FileSelector.html
+++ b/docs/r/reference/FileSelector.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FileSystem.html
+++ b/docs/r/reference/FileSystem.html
@@ -28,7 +28,7 @@ to another implementation after prepending a fixed base path"><meta property="og
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FileWriteOptions.html
+++ b/docs/r/reference/FileWriteOptions.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FixedWidthType.html
+++ b/docs/r/reference/FixedWidthType.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/FragmentScanOptions.html
+++ b/docs/r/reference/FragmentScanOptions.html
@@ -24,7 +24,7 @@ operation."><meta property="og:image" content="https://arrow.apache.org/img/arro
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/InputStream.html
+++ b/docs/r/reference/InputStream.html
@@ -28,7 +28,7 @@ buffer. Use these with the various table readers."><meta property="og:image" con
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/JsonFileFormat.html
+++ b/docs/r/reference/JsonFileFormat.html
@@ -24,7 +24,7 @@ read and parse the files included in a JSON Dataset."><meta property="og:image" 
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/MemoryPool.html
+++ b/docs/r/reference/MemoryPool.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Message.html
+++ b/docs/r/reference/Message.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/MessageReader.html
+++ b/docs/r/reference/MessageReader.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/OutputStream.html
+++ b/docs/r/reference/OutputStream.html
@@ -26,7 +26,7 @@ You can create one and pass it to any of the table writers, for example."><meta 
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ParquetArrowReaderProperties.html
+++ b/docs/r/reference/ParquetArrowReaderProperties.html
@@ -24,7 +24,7 @@ by ParquetFileReader."><meta property="og:image" content="https://arrow.apache.o
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ParquetFileReader.html
+++ b/docs/r/reference/ParquetFileReader.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ParquetFileWriter.html
+++ b/docs/r/reference/ParquetFileWriter.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ParquetReaderProperties.html
+++ b/docs/r/reference/ParquetReaderProperties.html
@@ -24,7 +24,7 @@ by ParquetFileReader."><meta property="og:image" content="https://arrow.apache.o
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/ParquetWriterProperties.html
+++ b/docs/r/reference/ParquetWriterProperties.html
@@ -24,7 +24,7 @@ by ParquetFileWriter."><meta property="og:image" content="https://arrow.apache.o
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Partitioning.html
+++ b/docs/r/reference/Partitioning.html
@@ -64,7 +64,7 @@ partition features from the file paths."><meta property="og:image" content="http
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/RecordBatch-class.html
+++ b/docs/r/reference/RecordBatch-class.html
@@ -26,7 +26,7 @@ a sequence of fields, each a contiguous Arrow Array."><meta property="og:image" 
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/RecordBatchReader.html
+++ b/docs/r/reference/RecordBatchReader.html
@@ -32,7 +32,7 @@ For guidance on how to use these classes, see the examples section.'><meta prope
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/RecordBatchWriter.html
+++ b/docs/r/reference/RecordBatchWriter.html
@@ -30,7 +30,7 @@ For guidance on how to use these classes, see the examples section.'><meta prope
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Scalar-class.html
+++ b/docs/r/reference/Scalar-class.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Scanner.html
+++ b/docs/r/reference/Scanner.html
@@ -26,7 +26,7 @@ can help create one."><meta property="og:image" content="https://arrow.apache.or
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Schema-class.html
+++ b/docs/r/reference/Schema-class.html
@@ -36,7 +36,7 @@ Many Arrow objects, including Table and Dataset, have a $schema method
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/Table-class.html
+++ b/docs/r/reference/Table-class.html
@@ -26,7 +26,7 @@ composed from multiple record batches or chunked arrays."><meta property="og:ima
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/acero.html
+++ b/docs/r/reference/acero.html
@@ -36,7 +36,7 @@ functions.'><meta property="og:image" content="https://arrow.apache.org/img/arro
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/add_filename.html
+++ b/docs/r/reference/add_filename.html
@@ -24,7 +24,7 @@ valid when querying on a FileSystemDataset."><meta property="og:image" content="
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/array-class.html
+++ b/docs/r/reference/array-class.html
@@ -28,7 +28,7 @@ and StructArray."><meta property="og:image" content="https://arrow.apache.org/im
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/arrow-package.html
+++ b/docs/r/reference/arrow-package.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/arrow_array.html
+++ b/docs/r/reference/arrow_array.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/arrow_info.html
+++ b/docs/r/reference/arrow_info.html
@@ -24,7 +24,7 @@ settings for the Arrow package. It may be useful for diagnostics."><meta propert
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/arrow_not_supported.html
+++ b/docs/r/reference/arrow_not_supported.html
@@ -36,7 +36,7 @@ too."><meta property="og:image" content="https://arrow.apache.org/img/arrow-logo
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_arrow_array.html
+++ b/docs/r/reference/as_arrow_array.html
@@ -30,7 +30,7 @@ as_arrow_array()."><meta property="og:image" content="https://arrow.apache.org/i
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_arrow_table.html
+++ b/docs/r/reference/as_arrow_table.html
@@ -24,7 +24,7 @@ as_arrow_table() converts a single object to an Arrow Table."><meta property="og
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_chunked_array.html
+++ b/docs/r/reference/as_chunked_array.html
@@ -26,7 +26,7 @@ ChunkedArray."><meta property="og:image" content="https://arrow.apache.org/img/a
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_data_type.html
+++ b/docs/r/reference/as_data_type.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_record_batch.html
+++ b/docs/r/reference/as_record_batch.html
@@ -24,7 +24,7 @@ as_record_batch() converts a single object to an Arrow RecordBatch."><meta prope
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_record_batch_reader.html
+++ b/docs/r/reference/as_record_batch_reader.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/as_schema.html
+++ b/docs/r/reference/as_schema.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/buffer.html
+++ b/docs/r/reference/buffer.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/call_function.html
+++ b/docs/r/reference/call_function.html
@@ -30,7 +30,7 @@ are callable with an arrow_ prefix."><meta property="og:image" content="https://
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/cast.html
+++ b/docs/r/reference/cast.html
@@ -24,7 +24,7 @@ It is more convenient to call inside dplyr pipelines than the method."><meta pro
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/cast_options.html
+++ b/docs/r/reference/cast_options.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/chunked_array.html
+++ b/docs/r/reference/chunked_array.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/codec_is_available.html
+++ b/docs/r/reference/codec_is_available.html
@@ -26,7 +26,7 @@ use."><meta property="og:image" content="https://arrow.apache.org/img/arrow-logo
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/compression.html
+++ b/docs/r/reference/compression.html
@@ -26,7 +26,7 @@ input or output stream."><meta property="og:image" content="https://arrow.apache
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/concat_arrays.html
+++ b/docs/r/reference/concat_arrays.html
@@ -28,7 +28,7 @@ single object, use ChunkedArray."><meta property="og:image" content="https://arr
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/concat_tables.html
+++ b/docs/r/reference/concat_tables.html
@@ -26,7 +26,7 @@ column that point at existing array data."><meta property="og:image" content="ht
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/contains_regex.html
+++ b/docs/r/reference/contains_regex.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/copy_files.html
+++ b/docs/r/reference/copy_files.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/cpu_count.html
+++ b/docs/r/reference/cpu_count.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/create_package_with_all_dependencies.html
+++ b/docs/r/reference/create_package_with_all_dependencies.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/csv_convert_options.html
+++ b/docs/r/reference/csv_convert_options.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/csv_parse_options.html
+++ b/docs/r/reference/csv_parse_options.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/csv_read_options.html
+++ b/docs/r/reference/csv_read_options.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/csv_write_options.html
+++ b/docs/r/reference/csv_write_options.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/data-type.html
+++ b/docs/r/reference/data-type.html
@@ -26,7 +26,7 @@ of these functions don't take arguments, but a few do."><meta property="og:image
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/dataset_factory.html
+++ b/docs/r/reference/dataset_factory.html
@@ -26,7 +26,7 @@ open_dataset()."><meta property="og:image" content="https://arrow.apache.org/img
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/default_memory_pool.html
+++ b/docs/r/reference/default_memory_pool.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/dictionary.html
+++ b/docs/r/reference/dictionary.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/enums.html
+++ b/docs/r/reference/enums.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/flight_connect.html
+++ b/docs/r/reference/flight_connect.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/flight_disconnect.html
+++ b/docs/r/reference/flight_disconnect.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/flight_get.html
+++ b/docs/r/reference/flight_get.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/flight_put.html
+++ b/docs/r/reference/flight_put.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/format_schema.html
+++ b/docs/r/reference/format_schema.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/get_stringr_pattern_options.html
+++ b/docs/r/reference/get_stringr_pattern_options.html
@@ -28,7 +28,7 @@ to control pattern matching behavior in internal arrow functions."><meta propert
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/gs_bucket.html
+++ b/docs/r/reference/gs_bucket.html
@@ -24,7 +24,7 @@ that holds onto its relative path"><meta property="og:image" content="https://ar
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/hive_partition.html
+++ b/docs/r/reference/hive_partition.html
@@ -24,7 +24,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/index.html
+++ b/docs/r/reference/index.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/infer_schema.html
+++ b/docs/r/reference/infer_schema.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/infer_type.html
+++ b/docs/r/reference/infer_type.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/install_arrow.html
+++ b/docs/r/reference/install_arrow.html
@@ -26,7 +26,7 @@ all necessary C++ dependencies."><meta property="og:image" content="https://arro
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/install_pyarrow.html
+++ b/docs/r/reference/install_pyarrow.html
@@ -24,7 +24,7 @@ installing it for use with reticulate."><meta property="og:image" content="https
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/io_thread_count.html
+++ b/docs/r/reference/io_thread_count.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/list_compute_functions.html
+++ b/docs/r/reference/list_compute_functions.html
@@ -26,7 +26,7 @@ called by name with an arrow_ prefix inside a dplyr verb."><meta property="og:im
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/list_flights.html
+++ b/docs/r/reference/list_flights.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/load_flight_server.html
+++ b/docs/r/reference/load_flight_server.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/make_readable_file.html
+++ b/docs/r/reference/make_readable_file.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/map_batches.html
+++ b/docs/r/reference/map_batches.html
@@ -32,7 +32,7 @@ stream of data in Arrow after it."><meta property="og:image" content="https://ar
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/match_arrow.html
+++ b/docs/r/reference/match_arrow.html
@@ -24,7 +24,7 @@ them. These functions expose the analogous functions in the Arrow C++ library.">
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/mmap_create.html
+++ b/docs/r/reference/mmap_create.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/mmap_open.html
+++ b/docs/r/reference/mmap_open.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/new_extension_type.html
+++ b/docs/r/reference/new_extension_type.html
@@ -34,7 +34,7 @@ vctrs extension type is probably sufficient."><meta property="og:image" content=
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/open_dataset.html
+++ b/docs/r/reference/open_dataset.html
@@ -30,7 +30,7 @@ Dataset, then use dplyr methods to query it."><meta property="og:image" content=
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/open_delim_dataset.html
+++ b/docs/r/reference/open_delim_dataset.html
@@ -26,7 +26,7 @@ for opening single files and functions for opening datasets."><meta property="og
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_delim_arrow.html
+++ b/docs/r/reference/read_delim_arrow.html
@@ -26,7 +26,7 @@ readr::read_delim(), and col_select was inspired by vroom::vroom()."><meta prope
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_feather.html
+++ b/docs/r/reference/read_feather.html
@@ -32,7 +32,7 @@ read_ipc_file() is an alias of read_feather()."><meta property="og:image" conten
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_ipc_stream.html
+++ b/docs/r/reference/read_ipc_stream.html
@@ -26,7 +26,7 @@ and read_feather() read those formats, respectively.'><meta property="og:image" 
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_json_arrow.html
+++ b/docs/r/reference/read_json_arrow.html
@@ -24,7 +24,7 @@ data frame or Arrow Table."><meta property="og:image" content="https://arrow.apa
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_message.html
+++ b/docs/r/reference/read_message.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_parquet.html
+++ b/docs/r/reference/read_parquet.html
@@ -24,7 +24,7 @@ This function enables you to read Parquet files into R."><meta property="og:imag
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/read_schema.html
+++ b/docs/r/reference/read_schema.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/record_batch.html
+++ b/docs/r/reference/record_batch.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/recycle_scalars.html
+++ b/docs/r/reference/recycle_scalars.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/reexports.html
+++ b/docs/r/reference/reexports.html
@@ -44,7 +44,7 @@ all_of, contains, ends_with, everything, last_col, matches, num_range, one_of, s
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/register_binding.html
+++ b/docs/r/reference/register_binding.html
@@ -26,7 +26,7 @@ Expressions. These are the basis for the .data mask inside dplyr methods."><meta
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/register_scalar_function.html
+++ b/docs/r/reference/register_scalar_function.html
@@ -36,7 +36,7 @@ of rows) as the input."><meta property="og:image" content="https://arrow.apache.
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/repeat_value_as_array.html
+++ b/docs/r/reference/repeat_value_as_array.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/s3_bucket.html
+++ b/docs/r/reference/s3_bucket.html
@@ -26,7 +26,7 @@ relative path."><meta property="og:image" content="https://arrow.apache.org/img/
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/scalar.html
+++ b/docs/r/reference/scalar.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/schema.html
+++ b/docs/r/reference/schema.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/show_exec_plan.html
+++ b/docs/r/reference/show_exec_plan.html
@@ -30,7 +30,7 @@ the dplyr::explain() and dplyr::show_query() methods."><meta property="og:image"
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/table.html
+++ b/docs/r/reference/table.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/to_arrow.html
+++ b/docs/r/reference/to_arrow.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/to_duckdb.html
+++ b/docs/r/reference/to_duckdb.html
@@ -26,7 +26,7 @@ collect() or compute() are called or a query is run against the table."><meta pr
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/unify_schemas.html
+++ b/docs/r/reference/unify_schemas.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/value_counts.html
+++ b/docs/r/reference/value_counts.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/vctrs_extension_array.html
+++ b/docs/r/reference/vctrs_extension_array.html
@@ -32,7 +32,7 @@ converted back into an R vector."><meta property="og:image" content="https://arr
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_csv_arrow.html
+++ b/docs/r/reference/write_csv_arrow.html
@@ -22,7 +22,7 @@
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_dataset.html
+++ b/docs/r/reference/write_dataset.html
@@ -26,7 +26,7 @@ make it much faster to read and query."><meta property="og:image" content="https
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_delim_dataset.html
+++ b/docs/r/reference/write_delim_dataset.html
@@ -24,7 +24,7 @@ between functions for writing datasets."><meta property="og:image" content="http
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_feather.html
+++ b/docs/r/reference/write_feather.html
@@ -40,7 +40,7 @@ write_ipc_file() can only write V2 files."><meta property="og:image" content="ht
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_ipc_stream.html
+++ b/docs/r/reference/write_ipc_stream.html
@@ -26,7 +26,7 @@ and write_feather() write those formats, respectively.'><meta property="og:image
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_parquet.html
+++ b/docs/r/reference/write_parquet.html
@@ -24,7 +24,7 @@ This function enables you to write Parquet files from R."><meta property="og:ima
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 

--- a/docs/r/reference/write_to_raw.html
+++ b/docs/r/reference/write_to_raw.html
@@ -28,7 +28,7 @@ access that buffer as a raw vector in R."><meta property="og:image" content="htt
     <a class="navbar-brand me-2" href="../index.html">Arrow R Package</a>
 
     <span class="version">
-      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0</small>
+      <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">17.0.0.1</small>
     </span>
 
 


### PR DESCRIPTION
The [arrow R docs](https://arrow.apache.org/docs/r/) currently show the latest version of the arrow R package as 17.0.0 when it's actually 17.0.0.1. This PR will fix that and is the result of me:

- Checking out the maint-17.0.0-r branch of apache/arrow
- Building the R docs from that
- Copying the built docs into a checkout of the asf-site branch apache/arrow-site
- Adding changes hunk by hunk so this PR doesn't introduce noise
- Creating this PR

There may be an easier way to do this so any ideas are welcome.

cc @jonkeane 