### PR TITLE
Add Arrow Go 18.0.0 release post

### DIFF
--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -69,7 +69,7 @@ includes:
 
 #### Bug Fixes
 
-* Fixed an inconsistency in `ValueOffset` between String and Binary Arrays [GO-41](https://github.com/apache/arrow-go/issues/41)
+* Fixed an inconsistency in `ValueOffset` between String and Binary Arrays [GH-41](https://github.com/apache/arrow-go/issues/41)
 
 ### Parquet
 

--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -74,7 +74,7 @@ includes:
 ### Parquet
 
 * Added support for LZ4_RAW compression codec [GH-43790](https://github.com/apache/arrow/issues/43790)
-* Fixed recovery from a panic in the file reader [GO-124](https://github.com/apache/arrow-go/pull/124)
+* Fixed recovery from a panic in the file reader [GH-124](https://github.com/apache/arrow-go/pull/124)
 
 ## Contributors
 

--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -64,7 +64,7 @@ includes:
 
 #### Features
 
-* Added the initial implementation for the Decimal32/Decimal64 data types [Go-120](https://github.com/apache/arrow-go/issues/120)
+* Added the initial implementation for the Decimal32/Decimal64 data types [GH-120](https://github.com/apache/arrow-go/issues/120)
 * Added `is_null`, `is_not_null` and `is_nan` function kernels to the `compute` package [GH-134](https://github.com/apache/arrow-go/issues/134)
 
 #### Bug Fixes

--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -42,7 +42,7 @@ issues on the new repository instead of the Arrow monorepo.
 
 ### Go Version
 
-With this release, the minimum Go version is now 1.22
+With this release, the minimum Go version is now 1.22.
 
 ### Arrow
 

--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -1,0 +1,91 @@
+---
+layout: post
+title: "Apache Arrow Go 18.0.0 Release"
+date: "2024-10-23 00:00:00"
+author: pmc
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+The Apache Arrow team is pleased to announce the v18.0.0 release of
+Apache Arrow Go. This release covers 35 resolved issues from
+11 contributors.
+
+## Release Highlights
+
+### Move to new Repository
+
+The Apache Arrow Go implementation has been shifted out of the Arrow monorepo and to its
+own repository now located at https://github.com/apache/arrow-go. This will enable fewer
+major version releases and facilitate more minor version/patch releases instead as it will
+detach the version number from the Arrow C++ and other implementations in the monorepo.
+
+Existing Go related issues have been moved to the new repository and please file any new
+issues on the new repository instead of the Arrow monorepo.
+
+### Go Version
+
+With this release, the minimum Go version is now 1.22
+
+### Arrow
+
+#### Canonical Extension Types
+
+There is a new [`extensions`](https://pkg.go.dev/github.com/apache/arrow-go/v18@v18.0.0/arrow/extensions) package 
+which implements [canonical extension types](https://arrow.apache.org/docs/format/CanonicalExtensions.html). This
+includes:
+
+* Opaque [GH-43455](https://github.com/apache/arrow/issues/43455)
+* JSON and UUID [GH-43764](https://github.com/apache/arrow/issues/43764)
+* Bool8 [GH-17682](https://github.com/apache/arrow/issues/17682)
+
+#### Features
+
+* Added the initial implementation for the Decimal32/Decimal64 data types [Go-120](https://github.com/apache/arrow-go/issues/120)
+* Added `is_null`, `is_not_null` and `is_nan` function kernels to the `compute` package [GH-134](https://github.com/apache/arrow-go/issues/134)
+
+#### Bug Fixes
+
+* Fixed an inconsistency in `ValueOffset` between String and Binary Arrays [GO-41](https://github.com/apache/arrow-go/issues/41)
+
+### Parquet
+
+* Added support for LZ4_RAW compression codec [GH-43790](https://github.com/apache/arrow/issues/43790)
+* Fixed recovery from a panic in the file reader [GO-124](https://github.com/apache/arrow-go/pull/124)
+
+## Contributors
+
+This release consists of contributions from 11 contributors in addition to the
+invaluable advice and support of the Apache Arrow community.
+
+```console
+$ git shortlog --perl-regexp --author='^((?!dependabot\[bot\]).*)$' -sn 8b7fde9..v18.0.0
+    17	Sutou Kouhei
+     8	Joel Lubinitsky
+     6	Matt Topol
+     6	Raúl Cumplido
+     2	Xin Hao
+     1	David Li
+     1	Nick Crews
+     1	Seb. V
+     1	Tom Scott-Coombes
+     1	rene-hess
+     1	yihao.dai
+```

--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -36,7 +36,7 @@ The Apache Arrow Go implementation has been shifted out of the Arrow monorepo an
 own repository now located at https://github.com/apache/arrow-go. This will enable fewer
 major version releases and facilitate more minor version/patch releases instead as it will
 detach the version number from the Arrow C++ and other implementations in the monorepo.
-
+Current users of Arrow Go will want to carefully note the breaking change to module paths this move causes. To upgrade to Arrow Go v18.0.0, ensure you properly update all relevant module paths in your `go.mod`, replacing all instances of `github.com/apache/arrow/go/` with `github.com/apache/arrow-go`.
 Existing Go related issues have been moved to the new repository and please file any new
 issues on the new repository instead of the Arrow monorepo.
 

--- a/_posts/2024-10-23-arrow-go-18.0.0-release.md
+++ b/_posts/2024-10-23-arrow-go-18.0.0-release.md
@@ -32,13 +32,19 @@ Apache Arrow Go. This release covers 35 resolved issues from
 
 ### Move to new Repository
 
-The Apache Arrow Go implementation has been shifted out of the Arrow monorepo and to its
-own repository now located at https://github.com/apache/arrow-go. This will enable fewer
-major version releases and facilitate more minor version/patch releases instead as it will
-detach the version number from the Arrow C++ and other implementations in the monorepo.
-Current users of Arrow Go will want to carefully note the breaking change to module paths this move causes. To upgrade to Arrow Go v18.0.0, ensure you properly update all relevant module paths in your `go.mod`, replacing all instances of `github.com/apache/arrow/go/` with `github.com/apache/arrow-go`.
-Existing Go related issues have been moved to the new repository and please file any new
-issues on the new repository instead of the Arrow monorepo.
+The Apache Arrow Go implementation has been shifted out of the Arrow monorepo
+and to its own repository now located at https://github.com/apache/arrow-go.
+This will enable fewer major version releases and facilitate more minor
+version/patch releases instead as it will detach the version number from the
+Arrow C++ and other implementations in the monorepo.
+
+Current users of Arrow Go will want to carefully note the breaking change to
+module paths this move causes. To upgrade to Arrow Go v18.0.0, ensure you
+properly update all relevant module paths in your `go.mod`, replacing all
+instances of `github.com/apache/arrow/go/` with `github.com/apache/arrow-go`.
+
+Existing Go related issues have been moved to the new repository and please file
+any new issues on the new repository instead of the Arrow monorepo.
 
 ### Go Version
 


### PR DESCRIPTION
Adding a release post for the 18.0.0 release of Arrow Go, feel free to tag any additional reviewers I missed. Thanks!