### PR TITLE
[Website] Add Rossi Sun to committer list

### DIFF
--- a/_data/committers.yml
+++ b/_data/committers.yml
@@ -424,6 +424,10 @@
   role: Committer
   alias: romainfrancois
   affiliation: Posit
+- name: Rossi Sun
+  role: Committer
+  alias: zanmato
+  affiliation: PingCAP
 - name: Ruihang Xia
   role: Committer
   alias: wayne


### PR DESCRIPTION
I became a committer of Apache Arrow on October 23, 2024. The mailing thread: https://lists.apache.org/thread/w66421ox74glnryot0vm0jjsvlxchg0z