### PR TITLE
minor: fix links in Go release

### DIFF
--- a/_posts/2025-01-13-arrow-go-18.1.0.md
+++ b/_posts/2025-01-13-arrow-go-18.1.0.md
@@ -24,7 +24,7 @@ limitations under the License.
 {% endcomment %}
 -->
 
-The Apache Arrow team is pleased to announce the v18.1.0 release of Apache Arrow Go. 
+The Apache Arrow team is pleased to announce the [v18.1.0](https://github.com/apache/arrow-go/releases/tag/v18.1.0) release of Apache Arrow Go. 
 This minor release covers 32 commits from 6 distinct contributors.
 
 ## Contributors
@@ -41,41 +41,41 @@ $ git shortlog -sn v18.0.0..v18.1.0
 ## Changelog
 
 ### What's Changed
-* GH-19: Add Code Of Conduct by @zeroshade in https://github.com/apache/arrow-go/pull/161
-* GH-22: Add issue template by @zeroshade in https://github.com/apache/arrow-go/pull/163
-* GH-26: Add Codeowners by @zeroshade in https://github.com/apache/arrow-go/pull/160
-* GH-41: [Array] Make String and Binary consistent by @zeroshade in https://github.com/apache/arrow-go/pull/165
-* fix(arrow/compute): fix scenario where prealloc output is missed by @zeroshade in https://github.com/apache/arrow-go/pull/167
-* fix: don't clobber saved frame pointer in arm64 assembly functions by @nsrip-dd in https://github.com/apache/arrow-go/pull/170
-* fix(parquet): Reading UUID columns by @zeroshade in https://github.com/apache/arrow-go/pull/173
-* fix(arrow/compute): compare kernels with UUID by @zeroshade in https://github.com/apache/arrow-go/pull/174
-* GH-23: Add PR template by @zeroshade in https://github.com/apache/arrow-go/pull/164
-* ci: add self-assignable issues by @zeroshade in https://github.com/apache/arrow-go/pull/176
-* feat(arrow/compute): Implement kernel for "not" function by @zeroshade in https://github.com/apache/arrow-go/pull/178
-* fix(arrow/cdata): handle export struct with no fields by @zeroshade in https://github.com/apache/arrow-go/pull/175
-* feat(arrow/compute): make is_nan dispatchable by @zeroshade in https://github.com/apache/arrow-go/pull/177
-* GH-20: Add CONTRIBUTING.md by @zeroshade in https://github.com/apache/arrow-go/pull/162
-* chore: bump google.golang.org/grpc from 1.67.1 to 1.68.0 by @zeroshade in https://github.com/apache/arrow-go/pull/190
-* feat(arrow/cdata): Add Implementation of Async C Data interface by @zeroshade in https://github.com/apache/arrow-go/pull/169
-* fix(arrow/memory/internal/cgoalloc): Remove usage of reflect.SliceHeader by @zeroshade in https://github.com/apache/arrow-go/pull/194
-* ci: update pkg-config to pkgconf on Homebrew by @zeroshade in https://github.com/apache/arrow-go/pull/198
-* ci: use correct GitHub Actions permission "contents" instead of "content" by @raulcd in https://github.com/apache/arrow-go/pull/200
-* feat(arrow/ipc): add functions to generate payloads by @zeroshade in https://github.com/apache/arrow-go/pull/196
-* fix(internal/json): add arrow_json_stdlib build tag by @toddtreece in https://github.com/apache/arrow-go/pull/199
-* feat(parquet/pqarrow): Add ForceLarge option by @zeroshade in https://github.com/apache/arrow-go/pull/197
-* fix(parquet/metadata): fix default unsigned int statistics by @zeroshade in https://github.com/apache/arrow-go/pull/210
-* chore: bump github.com/goccy/go-json to v0.10.4 by @toddtreece in https://github.com/apache/arrow-go/pull/218
-* feat(parquet): Move footerOffset into FileMetaData by @joechenrh in https://github.com/apache/arrow-go/pull/217
-* feat(arrow/ipc): implement lazy loading/zero-copy for IPC files by @zeroshade in https://github.com/apache/arrow-go/pull/216
-* chore(arrow/compute/expr): upgrade substrait-go by @zeroshade in https://github.com/apache/arrow-go/pull/234
-* chore: Update the project URL in apache/arrow-go by @kou in https://github.com/apache/arrow-go/pull/239
-* chore: Enable Java integration test by @kou in https://github.com/apache/arrow-go/pull/240
-* feat(parquet): Add support for Page Indexes by @zeroshade in https://github.com/apache/arrow-go/pull/223
-* chore: bump version by @zeroshade in https://github.com/apache/arrow-go/pull/241
+* GH-19: Add Code Of Conduct by @zeroshade in [#161](https://github.com/apache/arrow-go/pull/161)
+* GH-22: Add issue template by @zeroshade in [#163](https://github.com/apache/arrow-go/pull/163)
+* GH-26: Add Codeowners by @zeroshade in [#160](https://github.com/apache/arrow-go/pull/160)
+* GH-41: [Array] Make String and Binary consistent by @zeroshade in [#165](https://github.com/apache/arrow-go/pull/165)
+* fix(arrow/compute): fix scenario where prealloc output is missed by @zeroshade in [#167](https://github.com/apache/arrow-go/pull/167)
+* fix: don't clobber saved frame pointer in arm64 assembly functions by @nsrip-dd in [#170](https://github.com/apache/arrow-go/pull/170)
+* fix(parquet): Reading UUID columns by @zeroshade in [#173](https://github.com/apache/arrow-go/pull/173)
+* fix(arrow/compute): compare kernels with UUID by @zeroshade in [#174](https://github.com/apache/arrow-go/pull/174)
+* GH-23: Add PR template by @zeroshade in [#164](https://github.com/apache/arrow-go/pull/164)
+* ci: add self-assignable issues by @zeroshade in [#176](https://github.com/apache/arrow-go/pull/176)
+* feat(arrow/compute): Implement kernel for "not" function by @zeroshade in [#178](https://github.com/apache/arrow-go/pull/178)
+* fix(arrow/cdata): handle export struct with no fields by @zeroshade in [#175](https://github.com/apache/arrow-go/pull/175)
+* feat(arrow/compute): make is_nan dispatchable by @zeroshade in [#177](https://github.com/apache/arrow-go/pull/177)
+* GH-20: Add CONTRIBUTING.md by @zeroshade in [#162](https://github.com/apache/arrow-go/pull/162)
+* chore: bump google.golang.org/grpc from 1.67.1 to 1.68.0 by @zeroshade in [#190](https://github.com/apache/arrow-go/pull/190)
+* feat(arrow/cdata): Add Implementation of Async C Data interface by @zeroshade in [#169](https://github.com/apache/arrow-go/pull/169)
+* fix(arrow/memory/internal/cgoalloc): Remove usage of reflect.SliceHeader by @zeroshade in [#194](https://github.com/apache/arrow-go/pull/194)
+* ci: update pkg-config to pkgconf on Homebrew by @zeroshade in [#198](https://github.com/apache/arrow-go/pull/198)
+* ci: use correct GitHub Actions permission "contents" instead of "content" by @raulcd in [#200](https://github.com/apache/arrow-go/pull/200)
+* feat(arrow/ipc): add functions to generate payloads by @zeroshade in [#196](https://github.com/apache/arrow-go/pull/196)
+* fix(internal/json): add arrow_json_stdlib build tag by @toddtreece in [#199](https://github.com/apache/arrow-go/pull/199)
+* feat(parquet/pqarrow): Add ForceLarge option by @zeroshade in [#197](https://github.com/apache/arrow-go/pull/197)
+* fix(parquet/metadata): fix default unsigned int statistics by @zeroshade in [#210](https://github.com/apache/arrow-go/pull/210)
+* chore: bump github.com/goccy/go-json to v0.10.4 by @toddtreece in [#218](https://github.com/apache/arrow-go/pull/218)
+* feat(parquet): Move footerOffset into FileMetaData by @joechenrh in [#217](https://github.com/apache/arrow-go/pull/217)
+* feat(arrow/ipc): implement lazy loading/zero-copy for IPC files by @zeroshade in [#216](https://github.com/apache/arrow-go/pull/216)
+* chore(arrow/compute/expr): upgrade substrait-go by @zeroshade in [#234](https://github.com/apache/arrow-go/pull/234)
+* chore: Update the project URL in apache/arrow-go by @kou in [#239](https://github.com/apache/arrow-go/pull/239)
+* chore: Enable Java integration test by @kou in [#240](https://github.com/apache/arrow-go/pull/240)
+* feat(parquet): Add support for Page Indexes by @zeroshade in [#223](https://github.com/apache/arrow-go/pull/223)
+* chore: bump version by @zeroshade in [#241](https://github.com/apache/arrow-go/pull/241)
 
 ### New Contributors
-* @nsrip-dd made their first contribution in https://github.com/apache/arrow-go/pull/170
-* @toddtreece made their first contribution in https://github.com/apache/arrow-go/pull/199
-* @joechenrh made their first contribution in https://github.com/apache/arrow-go/pull/217
+* @nsrip-dd made their first contribution in [#170](https://github.com/apache/arrow-go/pull/170)
+* @toddtreece made their first contribution in [#199](https://github.com/apache/arrow-go/pull/199)
+* @joechenrh made their first contribution in [#217](https://github.com/apache/arrow-go/pull/217)
 
-**Full Changelog**: https://github.com/apache/arrow-go/compare/v18.0.0...v18.1.0
+**Full Changelog**: [changelog](https://github.com/apache/arrow-go/compare/v18.0.0...v18.1.0)


### PR DESCRIPTION
Didn't realize until after it deployed that the links weren't rendered correctly. So need to fix them (and then update the script to do this in the future).