### PR TITLE
Website: Add blog post for 19.0.0

### DIFF
--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -128,10 +128,6 @@ row groups. This may be useful to pre-buffer file data via caching mechanisms. (
 
 We've added `arrow::Result`-returning variants for `parquet::arrow::OpenFile()` and `parquet::arrow::FileReader::GetRecordBatchReader()`  ([GH-44784](https://github.com/apache/arrow/issues/44784), [GH-44808](https://github.com/apache/arrow/issues/44808))
 
-### Miscellaneous
-
-`ChunkResolver` is now exposed as a public API (GH-34535).
-
 ## C# notes
 
 * The `PrimitiveArrayBuilder` constructor has been made public to allow writing custom builders ([#23995](https://github.com/apache/arrow/issues/23995))

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -44,7 +44,18 @@ Thanks for your contributions and participation in the project!
 
 ## Columnar format
 
-TODO
+We've added a new experimental specification for statistics schema. It's useful
+to exchange statistics. See [the statistics schema
+documentation](https://arrow.apache.org/docs/format/StatisticsSchema.html) for
+details.
+
+There's also an expansion of the C Device ABI to include an experimental Async
+Device Stream Interface. While the existing C Device Interface is a
+pull-oriented API, the Async interface provides a push-oriented design for other
+workflows. See the
+[documentation](https://arrow.apache.org/docs/format/CDeviceDataInterface.html#async-device-stream-interface)
+for more information. It currently has implementations in the C++ and Go
+libraries.
 
 ## Arrow Flight RPC notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -106,11 +106,6 @@ The Java project has moved to a separate repository outside the main Arrow
 monorepo. For notes on the latest release of the Java implementation, see the
 latest [Arrow Java changelog][7].
 
-## JavaScript notes
-
-TODO
-
-
 ## Python notes
 
 TODO

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -106,12 +106,6 @@ The Azure filesystem now supports SAS token authentication (GH-44308).
 - The UCX backend has been deprecated and is scheduled for removal.
   ([GH-45079](https://github.com/apache/arrow/issues/)).
 
-### Memory management
-
-Mimalloc is now the default allocator, while jemalloc is disabled by default
-due to reports of compatibility issues on various platforms (GH-44976). While
-we do not expect this to cause any functional regression, it may lead to different
-memory consumption and performance characteristics in memory-intensive workloads.
 
 ### Parquet
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -82,7 +82,14 @@ The Azure filesystem now supports SAS token authentication (GH-44308).
 
 ### Flight RPC
 
-The UCX backend has been deprecated and is scheduled for removal (GH-45079).
+- The precision of a Timestamp (used for timeouts) is now nanoseconds on all
+  platforms; previously it was platform-dependent.
+  ([#44679](https://github.com/apache/arrow/issues/44679))
+- The Python bindings now support various new fields that were added to
+  FlightEndpoint/FlightInfo (like `expiration_time`).
+  ([#36954](https://github.com/apache/arrow/issues/36954))
+- The UCX backend has been deprecated and is scheduled for removal.
+  ([GH-45079](https://github.com/apache/arrow/issues/)).
 
 ### Memory management
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -42,6 +42,19 @@ Committee (PMC).
 
 Thanks for your contributions and participation in the project!
 
+## Release Highlights
+
+A [bug](https://github.com/apache/arrow/issues/45283) has been identified in the
+19.0.0 versions of the C++ and Python libraries which prevents reading Parquet
+files written by Arrow Rust v53.0.0 or higher. The files written by Arrow Rust
+are correct and the bug was in the patch adding support for Parquet's new
+[SizeStatistics](https://github.com/apache/parquet-format/pull/197) feature to
+Arrow C++ and Python. See [#45293](https://github.com/apache/arrow/issues/45283)
+for more details including a potential workaround.
+
+As a result, we plan to create a 19.0.1 release to include a fix for this which
+should be available in next few weeks.
+
 ## Columnar Format
 
 We've added a new experimental specification for representing statistics on

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -133,7 +133,10 @@ TODO
 
 ### C GLib
 
-TODO
+- Added support for 64bit decimal
+- Added support for 32bit decimal
+- Added support for binary view data type
+- Added support for string view data type
 
 ## Rust notes and Go notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -159,18 +159,33 @@ latest release of the [Go implementation](https://github.com/apache/arrow-go), s
 
 New features:
 
-* Support for 32-bit and 64-bit decimal types was added [GH-44713](https://github.com/apache/arrow/issues/44713)
-* Pandas 3.0 default string dtype is supported [GH-43683](https://github.com/apache/arrow/issues/43683)
-* Arrow PyCapsule stream objects are supported in `write_dataset` [GH-43410](https://github.com/apache/arrow/issues/43410)
-* New Flight features have been exposed [GH-36954](https://github.com/apache/arrow/issues/36954)
-* Bindings for `JsonExtensionType` and `JsonArray` are added [GH-44066](https://github.com/apache/arrow/issues/44066)
-* Hyperbolic trigonometry functions added to the Arrow C++ compute kernels are also available in PyArrow [GH-44952](https://github.com/apache/arrow/issues/44952)
+- The upcoming pandas 3.0 [string
+  dtype](https://pandas.pydata.org/pdeps/0014-string-dtype.html) is now
+  supported by PyArrow's `to_pandas` routine. In the future, when using pandas
+  >= 3.0, the new pandas behavior will be enabled by default. You can opt into
+  the new behavior under pandas >=2.3 by setting `pd.options.future.infer_string
+  = True`. This may be considered a breaking change.
+  ([#43683](https://github.com/apache/arrow/issues/43683))
+- Support for 32-bit and 64-bit decimal types was added.
+  ([#44713](https://github.com/apache/arrow/issues/44713))
+- Arrow PyCapsule stream objects are supported in `write_dataset`.
+  ([#43410](https://github.com/apache/arrow/issues/43410))
+- New Flight features have been exposed.
+  ([#36954](https://github.com/apache/arrow/issues/36954))
+- Bindings for `JsonExtensionType` and `JsonArray` were added.
+  ([#44066](https://github.com/apache/arrow/issues/44066))
+- Hyperbolic trigonometry functions added to the Arrow C++ compute kernels are
+  also available in PyArrow.
+  ([#44952](https://github.com/apache/arrow/issues/44952))
 
 Other improvements:
 
-* `strings_to_categorical` keyword in `to_pandas` can now be used for string view type also [GH-45175](https://github.com/apache/arrow/issues/45175)
-* from_buffers is updated to work with` StringView` GH-44651 https://github.com/apache/arrow/issues/44651
-* Version suffixes are also set for Arrow Python C++ (libarrow_python*) libraries [GH-44614](https://github.com/apache/arrow/issues/44614)
+- `strings_to_categorical` keyword in `to_pandas` can now be used for string
+  view type. ([#45175](https://github.com/apache/arrow/issues/45175))
+- `from_buffers` is updated to work with `StringView`.
+  ([#44651](https://github.com/apache/arrow/issues/44651))
+- Version suffixes are also set for Arrow Python C++ (`libarrow_python*`).
+  libraries ([#44614](https://github.com/apache/arrow/issues/44614))
 
 ## Ruby and C GLib Notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -1,0 +1,137 @@
+---
+layout: post
+title: "Apache Arrow 19.0.0 Release"
+date: "2025-01-16 00:00:00"
+author: pmc
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+The Apache Arrow team is pleased to announce the 19.0.0 release. This release
+covers over 2 months of development work and includes [**202 resolved
+issues**][1] on [**330 distinct commits**][2] from [**67 distinct
+contributors**][2]. See the [Install Page](https://arrow.apache.org/install/) to
+learn how to get the libraries for your platform.
+
+The release notes below are not exhaustive and only expose selected highlights
+of the release. Many other bugfixes and improvements have been made: we refer
+you to the [complete changelog][3].
+
+## Community
+
+Since the 18.1.0 release, Adam Reeve and Laurent Goujon have been invited to
+become committers. Gang Wu has been invited to join the Project Management
+Committee (PMC).
+
+Thanks for your contributions and participation in the project!
+
+## Columnar format
+
+TODO
+
+## Arrow Flight RPC notes
+
+TODO
+
+## C++ notes
+
+TODO
+
+### Acero
+
+TODO
+
+### Compute
+
+TODO
+
+### Dataset
+
+
+### Filesystems
+
+TODO
+
+### Gandiva
+
+TODO
+
+### GPU
+
+
+### IPC
+
+TODO
+
+### Parquet
+
+TODO
+
+## C# notes
+
+TODO
+
+## Java notes
+
+The Java project has moved to a separate repository outside the main Arrow
+monorepo. For notes on the latest release of the Java implementation, see the
+latest [Arrow Java changelog][7].
+
+## JavaScript notes
+
+TODO
+
+
+## Python notes
+
+TODO
+
+## R notes
+
+TODO
+
+## Ruby and C GLib notes
+
+### Ruby
+
+TODO
+
+### C GLib
+
+TODO
+
+## Rust notes and Go notes
+
+The Rust and Go projects have moved to separate repositories outside the main
+Arrow monorepo. For notes on the latest release of the Rust implementation, see
+the latest [Arrow Rust changelog][5]. For notes on the latest release of the Go
+implementation, see the latest [Arrow Go changelog][6]
+
+## Linux packages notes
+
+TODO
+
+[1]: https://github.com/apache/arrow/milestone/66?closed=1
+[2]: {{ site.baseurl }}/release/19.0.0.html#contributors
+[3]: {{ site.baseurl }}/release/19.0.0.html#changelog
+[4]: {{ site.baseurl }}/docs/r/news/
+[5]: https://github.com/apache/arrow-rs/tags
+[6]: https://github.com/apache/arrow-go/tags
+[7]: https://github.com/apache/arrow-java/tags

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -42,58 +42,68 @@ Committee (PMC).
 
 Thanks for your contributions and participation in the project!
 
-## Columnar format
+## Columnar Format
 
-We've added a new experimental specification for statistics schema. It's useful
-to exchange statistics. See [the statistics schema
+We've added a new experimental specification for representing statistics on
+Arrow Arrays as Arrow Arrays. This is useful for preserving and exchanging
+statistics between systems such as when converting Parquet data to Arrow. See
+[the statistics schema
 documentation](https://arrow.apache.org/docs/format/StatisticsSchema.html) for
 details.
 
-There's also an expansion of the C Device ABI to include an experimental Async
-Device Stream Interface. While the existing C Device Interface is a
-pull-oriented API, the Async interface provides a push-oriented design for other
-workflows. See the
+We've expanded the Arrow C Device Data Interface to include an experimental
+Async Device Stream Interface. While the existing Arrow C Device Data Interface
+is a pull-oriented API, the Async interface provides a push-oriented design for
+other workflows. See the
 [documentation](https://arrow.apache.org/docs/format/CDeviceDataInterface.html#async-device-stream-interface)
 for more information. It currently has implementations in the C++ and Go
 libraries.
 
-## Arrow Flight RPC notes
+## Arrow Flight RPC Notes
 
-- The precision of a Timestamp (used for timeouts) is now nanoseconds on all platforms; previously it was platform-dependent. ([#44679](https://github.com/apache/arrow/issues/44679))
-- The Python bindings now support various new fields that were added to FlightEndpoint/FlightInfo (like `expiration_time`). ([#36954](https://github.com/apache/arrow/issues/36954))
+The precision of a Timestamp (used for timeouts) is now nanoseconds on all
+platforms; previously it was platform-dependent.
+([#44679](https://github.com/apache/arrow/issues/44679))
 
-## C++ notes
+The Python bindings now support various new fields that were added to
+FlightEndpoint/FlightInfo (like `expiration_time`).
+([#36954](https://github.com/apache/arrow/issues/36954))
+
+## C++ Notes
 
 ### Compute
 
-It is now possible to cast from a struct type to another struct type with
-additional columns, provided the additional columns are nullable (GH-44555).
+- It is now possible to cast from a struct type to another struct type with
+additional columns, provided the additional columns are nullable
+([#44555)](https://github.com/apache/arrow/issues/44555).
 
-The compute function `expm1` has been added to compute `exp(x) - 1` with better
-accuracy when the input value is close to 0 (GH-44903).
-
-Hyperbolic trigonometric functions and their reciprocals have also been added
-(GH-44952).
-
-The new Decimal32 and Decimal64 types have been further supported by allowing
+- The compute function `expm1` has been added to compute `exp(x) - 1` with better
+accuracy when the input value is close to 0
+([#44903](https://github.com/apache/arrow/issues/44903)).
+- Hyperbolic trigonometric functions and their reciprocals have also been added
+([#44952](https://github.com/apache/arrow/issues/44952)).
+- The new Decimal32 and Decimal64 types have been further supported by allowing
 casting between numeric, string, and other decimal types
-([GH-43956](https://github.com/apache/arrow/issues/43956)).
+([#43956](https://github.com/apache/arrow/issues/43956)).
 
 ### Acero
 
-Added AVX2 support for decoding row tables in the Swiss join specialization of
+- Added AVX2 support for decoding row tables in the Swiss join specialization of
 hash joins, enabling up to 40% performance improvement for build-heavy workloads
-([GH-43693](https://github.com/apache/arrow/issues/43693)).
+([#43693](https://github.com/apache/arrow/issues/43693)).
 
 ### Filesystems
 
-The S3 filesystem has gained support for server-side encryption with customer
-provided keys, aka SSE-C (GH-43535).
+- The S3 filesystem has gained support for server-side encryption with customer
+provided keys, aka SSE-C
+([#43535](https://github.com/apache/arrow/issues/43535)).
 
-The S3 filesystem also gained an option to disable the SIGPIPE signals that may
-be emitted on some network events (GH-44695).
+- The S3 filesystem also gained an option to disable the SIGPIPE signals that may
+be emitted on some network events
+([#44695](https://github.com/apache/arrow/issues/44695)).
 
-The Azure filesystem now supports SAS token authentication (GH-44308).
+- The Azure filesystem now supports SAS token authentication
+([#44308](https://github.com/apache/arrow/issues/44308)).
 
 ### Flight RPC
 
@@ -104,28 +114,30 @@ The Azure filesystem now supports SAS token authentication (GH-44308).
   FlightEndpoint/FlightInfo (like `expiration_time`).
   ([#36954](https://github.com/apache/arrow/issues/36954))
 - The UCX backend has been deprecated and is scheduled for removal.
-  ([GH-45079](https://github.com/apache/arrow/issues/)).
-
+  ([#45079](https://github.com/apache/arrow/issues/45079)).
 
 ### Parquet
 
-The initial footer read size can now be configured to reduce the number of
-potential roundtrips on high-latency filesystems such as S3 (GH-45015).
-
-The new SizeStatistics format feature has been implemented, though it is
-disabled by default when writing (GH-40592).
-
-We've added a new method to the ParquetFileReader class,
+- The initial footer read size can now be configured to reduce the number of
+potential round-trips on hi-latency filesystems such as S3. ([#45015](https://github.com/apache/arrow/issues/45015)).
+- The new `SizeStatistics` format feature has been implemented, though it is
+disabled by default when writing. ([#40592](https://github.com/apache/arrow/issues/40592)).
+- We've added a new method to the ParquetFileReader class,
 [GetReadRanges](https://arrow.apache.org/docs/cpp/api/formats.html#_CPPv4N7parquet17ParquetFileReader13GetReadRangesERKNSt6vectorIiEERKNSt6vectorIiEE7int64_t7int64_t),
 which can calculate the byte ranges necessary to read a given set of columns and
-row groups. This may be useful to pre-buffer file data via caching mechanisms. ([GH-45092](https://github.com/apache/arrow/issues/45092))
-
-We've added `arrow::Result`-returning variants for `parquet::arrow::OpenFile()` and `parquet::arrow::FileReader::GetRecordBatchReader()`  ([GH-44784](https://github.com/apache/arrow/issues/44784), [GH-44808](https://github.com/apache/arrow/issues/44808))
+row groups. This may be useful to pre-buffer file data via caching mechanisms.
+([#45092](https://github.com/apache/arrow/issues/45092))
+- We've added `arrow::Result`-returning variants for `parquet::arrow::OpenFile()`
+and `parquet::arrow::FileReader::GetRecordBatchReader()`.
+([#44784](https://github.com/apache/arrow/issues/44784),
+[#44808](https://github.com/apache/arrow/issues/44808))
 
 ## C# notes
 
-* The `PrimitiveArrayBuilder` constructor has been made public to allow writing custom builders ([#23995](https://github.com/apache/arrow/issues/23995))
-* Improved the performance of looking up schema fields by name ([#44575](https://github.com/apache/arrow/issues/44575))
+- The `PrimitiveArrayBuilder` constructor has been made public to allow writing
+  custom builders. ([#23995](https://github.com/apache/arrow/issues/23995))
+- Improved the performance of looking up schema fields by name.
+  ([#44575](https://github.com/apache/arrow/issues/44575))
 
 ## Java notes
 
@@ -142,24 +154,24 @@ TODO
 ### Ruby
 
 - Added basic support for JRuby with an implementation based on Arrow Java
-  ([GH-44346](https://github.com/apache/arrow/pull/44346)). The plan is to release
+  ([#44346](https://github.com/apache/arrow/pull/44346)). The plan is to release
   this as a gem once it covers a base set of features. See
-  [GH-45324](https://github.com/apache/arrow/issues/45324) for more information.
+  [#45324](https://github.com/apache/arrow/issues/45324) for more information.
 - Added support for 32bit and 64bit decimal, binary view, and string view. See
   [issues
   listed](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
-  in the 19.0.0 milestone.
-- Fixed a bug that empty struct list can't be built
-  ([GH-44742](https://github.com/apache/arrow/issues/44742))
-- Fixed a bug that `record_batch[:colun].size` raises an exception
-  ([GH-45119](https://github.com/apache/arrow/issues/45119))
+  in the 19.0.0 milestone for more details.
+- Fixed a bug that empty struct list can't be built.
+  ([#44742](https://github.com/apache/arrow/issues/44742))
+- Fixed a bug that `record_batch[:column].size` raises an exception.
+  ([#45119](https://github.com/apache/arrow/issues/45119))
 
 ### C GLib
 
 - Added support for 32bit and 64bit decimal, binary view, and string view. See
   [issues
-  listed](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
-  in the 19.0.0 milestone.
+  listed in the 19.0.0 milestone](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
+  for more details.
 
 ## Rust notes and Go notes
 
@@ -171,7 +183,7 @@ implementation, see the latest [Arrow Go changelog][6]
 ## Linux packages notes
 
 - Debian: Fixed keyring format to support newer libapt (e.g., that used by
-  Trixie) ([GH-45118](https://github.com/apache/arrow/issues/45118))
+  Trixie). ([#45118](https://github.com/apache/arrow/issues/45118))
 
 [1]: https://github.com/apache/arrow/milestone/66?closed=1
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -125,10 +125,6 @@ latest [Arrow Java changelog][7].
 
 TODO
 
-## R notes
-
-TODO
-
 ## Ruby and C GLib notes
 
 ### Ruby

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -234,6 +234,6 @@ Other improvements:
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors
 [3]: {{ site.baseurl }}/release/19.0.0.html#changelog
 [4]: {{ site.baseurl }}/docs/r/news/
-[5]: https://github.com/apache/arrow-rs/tags
-[6]: https://github.com/apache/arrow-go/tags
-[7]: https://github.com/apache/arrow-java/tags
+[5]: https://github.com/apache/arrow-rs/releases
+[6]: https://github.com/apache/arrow-go/releases
+[7]: https://github.com/apache/arrow-java/releases

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -121,6 +121,13 @@ potential roundtrips on high-latency filesystems such as S3 (GH-45015).
 The new SizeStatistics format feature has been implemented, though it is
 disabled by default when writing (GH-40592).
 
+We've added a new method to the ParquetFileReader class,
+[GetReadRanges](https://arrow.apache.org/docs/cpp/api/formats.html#_CPPv4N7parquet17ParquetFileReader13GetReadRangesERKNSt6vectorIiEERKNSt6vectorIiEE7int64_t7int64_t),
+which can calculate the byte ranges necessary to read a given set of columns and
+row groups. This may be useful to pre-buffer file data via caching mechanisms. ([GH-45092](https://github.com/apache/arrow/issues/45092))
+
+We've added `arrow::Result`-returning variants for `parquet::arrow::OpenFile()` and `parquet::arrow::FileReader::GetRecordBatchReader()`  ([GH-44784](https://github.com/apache/arrow/issues/44784), [GH-44808](https://github.com/apache/arrow/issues/44808))
+
 ### Miscellaneous
 
 `ChunkResolver` is now exposed as a public API (GH-34535).

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -162,8 +162,8 @@ implementation, see the latest [Arrow Go changelog][6]
 
 ## Linux packages notes
 
-- Enabled Azure file system
-- deb: Fixed keyring format for newer libapt
+- Debian: Fixed keyring format to support newer libapt (e.g., that used by
+  Trixie) ([GH-45118](https://github.com/apache/arrow/issues/45118))
 
 [1]: https://github.com/apache/arrow/milestone/66?closed=1
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -123,20 +123,25 @@ TODO
 
 ### Ruby
 
-- Added support for JRuby but it's not released as a gem yet. It's based on the Java implementation. It still has only a few basic features. We'll release it as a gem when it covers all base features.
-- Added support for 64bit decimal
-- Added support for 32bit decimal
-- Added support for binary view data type
-- Added support for string view data type
+- Added basic support for JRuby with an implementation based on Arrow Java
+  ([GH-44346](https://github.com/apache/arrow/pull/44346)). The plan is to release
+  this as a gem once it covers a base set of features. See
+  [GH-45324](https://github.com/apache/arrow/issues/45324) for more information.
+- Added support for 32bit and 64bit decimal, binary view, and string view. See
+  [issues
+  listed](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
+  in the 19.0.0 milestone.
 - Fixed a bug that empty struct list can't be built
+  ([GH-44742](https://github.com/apache/arrow/issues/44742))
 - Fixed a bug that `record_batch[:colun].size` raises an exception
+  ([GH-45119](https://github.com/apache/arrow/issues/45119))
 
 ### C GLib
 
-- Added support for 64bit decimal
-- Added support for 32bit decimal
-- Added support for binary view data type
-- Added support for string view data type
+- Added support for 32bit and 64bit decimal, binary view, and string view. See
+  [issues
+  listed](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
+  in the 19.0.0 milestone.
 
 ## Rust notes and Go notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -123,7 +123,13 @@ TODO
 
 ### Ruby
 
-TODO
+- Added support for JRuby but it's not released as a gem yet. It's based on the Java implementation. It still has only a few basic features. We'll release it as a gem when it covers all base features.
+- Added support for 64bit decimal
+- Added support for 32bit decimal
+- Added support for binary view data type
+- Added support for string view data type
+- Fixed a bug that empty struct list can't be built
+- Fixed a bug that `record_batch[:colun].size` raises an exception
 
 ### C GLib
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -132,24 +132,34 @@ and `parquet::arrow::FileReader::GetRecordBatchReader()`.
 ([#44784](https://github.com/apache/arrow/issues/44784),
 [#44808](https://github.com/apache/arrow/issues/44808))
 
-## C# notes
+## C# Notes
 
 - The `PrimitiveArrayBuilder` constructor has been made public to allow writing
   custom builders. ([#23995](https://github.com/apache/arrow/issues/23995))
 - Improved the performance of looking up schema fields by name.
   ([#44575](https://github.com/apache/arrow/issues/44575))
 
-## Java notes
+## Java, Go, and Rust Notes
 
-The Java project has moved to a separate repository outside the main Arrow
-monorepo. For notes on the latest release of the Java implementation, see the
+The Java, Go, and Rust Go projects have moved to separate repositories outside
+the main Arrow monorepo.
+
+- For notes on the latest release of the [Java implementation](https://github.com/apache/arrow-java), see the
 latest [Arrow Java changelog][7].
+- For notes on the latest release of the [Rust implementation](https://github.com/apache/arrow-rs) see the latest [Arrow Rust changelog][5].
+- For notes on the
+latest release of the [Go implementation](https://github.com/apache/arrow-go), see the latest [Arrow Go changelog][6]
 
-## Python notes
+## Linux Packaging Notes
+
+- Debian: Fixed keyring format to support newer libapt (e.g., that used by
+  Trixie). ([#45118](https://github.com/apache/arrow/issues/45118))
+
+## Python Notes
 
 TODO
 
-## Ruby and C GLib notes
+## Ruby and C GLib Notes
 
 ### Ruby
 
@@ -173,17 +183,6 @@ TODO
   listed in the 19.0.0 milestone](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
   for more details.
 
-## Rust notes and Go notes
-
-The Rust and Go projects have moved to separate repositories outside the main
-Arrow monorepo. For notes on the latest release of the Rust implementation, see
-the latest [Arrow Rust changelog][5]. For notes on the latest release of the Go
-implementation, see the latest [Arrow Go changelog][6]
-
-## Linux packages notes
-
-- Debian: Fixed keyring format to support newer libapt (e.g., that used by
-  Trixie). ([#45118](https://github.com/apache/arrow/issues/45118))
 
 [1]: https://github.com/apache/arrow/milestone/66?closed=1
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -77,11 +77,10 @@ FlightEndpoint/FlightInfo (like `expiration_time`).
 - It is now possible to cast from a struct type to another struct type with
 additional columns, provided the additional columns are nullable
 ([#44555)](https://github.com/apache/arrow/issues/44555).
-
 - The compute function `expm1` has been added to compute `exp(x) - 1` with better
 accuracy when the input value is close to 0
 ([#44903](https://github.com/apache/arrow/issues/44903)).
-- Hyperbolic trigonometric functions and their reciprocals have also been added
+- Hyperbolic trigonometric functions and their reciprocals have also been added.
 ([#44952](https://github.com/apache/arrow/issues/44952)).
 - The new Decimal32 and Decimal64 types have been further supported by allowing
 casting between numeric, string, and other decimal types
@@ -90,46 +89,48 @@ casting between numeric, string, and other decimal types
 ### Acero
 
 - Added AVX2 support for decoding row tables in the Swiss join specialization of
-hash joins, enabling up to 40% performance improvement for build-heavy workloads
-([#43693](https://github.com/apache/arrow/issues/43693)).
+hash joins, enabling up to 40% performance improvement for build-heavy
+workloads. ([#43693](https://github.com/apache/arrow/issues/43693))
 
 ### Filesystems
 
 - The S3 filesystem has gained support for server-side encryption with customer
-provided keys, aka SSE-C
-([#43535](https://github.com/apache/arrow/issues/43535)).
-
-- The S3 filesystem also gained an option to disable the SIGPIPE signals that may
-be emitted on some network events
-([#44695](https://github.com/apache/arrow/issues/44695)).
-
-- The Azure filesystem now supports SAS token authentication
+provided keys, aka SSE-C.
+([#43535](https://github.com/apache/arrow/issues/43535))
+- The S3 filesystem also gained an option to disable the SIGPIPE signals that
+may be emitted on some network events.
+([#44695](https://github.com/apache/arrow/issues/44695))
+- The Azure filesystem now supports SAS token authentication.
 ([#44308](https://github.com/apache/arrow/issues/44308)).
 
 ### Flight RPC
 
 - The precision of a Timestamp (used for timeouts) is now nanoseconds on all
-  platforms; previously it was platform-dependent.
+  platforms; previously it was platform-dependent. This may be a breaking change
+depending on your use case.
   ([#44679](https://github.com/apache/arrow/issues/44679))
 - The Python bindings now support various new fields that were added to
   FlightEndpoint/FlightInfo (like `expiration_time`).
   ([#36954](https://github.com/apache/arrow/issues/36954))
 - The UCX backend has been deprecated and is scheduled for removal.
-  ([#45079](https://github.com/apache/arrow/issues/45079)).
+  ([#45079](https://github.com/apache/arrow/issues/45079))
 
 ### Parquet
 
 - The initial footer read size can now be configured to reduce the number of
-potential round-trips on hi-latency filesystems such as S3. ([#45015](https://github.com/apache/arrow/issues/45015)).
+potential round-trips on hi-latency filesystems such as S3.
+([#45015](https://github.com/apache/arrow/issues/45015))
 - The new `SizeStatistics` format feature has been implemented, though it is
-disabled by default when writing. ([#40592](https://github.com/apache/arrow/issues/40592)).
+disabled by default when writing.
+([#40592](https://github.com/apache/arrow/issues/40592))
 - We've added a new method to the ParquetFileReader class,
 [GetReadRanges](https://arrow.apache.org/docs/cpp/api/formats.html#_CPPv4N7parquet17ParquetFileReader13GetReadRangesERKNSt6vectorIiEERKNSt6vectorIiEE7int64_t7int64_t),
 which can calculate the byte ranges necessary to read a given set of columns and
 row groups. This may be useful to pre-buffer file data via caching mechanisms.
 ([#45092](https://github.com/apache/arrow/issues/45092))
-- We've added `arrow::Result`-returning variants for `parquet::arrow::OpenFile()`
-and `parquet::arrow::FileReader::GetRecordBatchReader()`.
+- We've added `arrow::Result`-returning variants for
+`parquet::arrow::OpenFile()` and
+`parquet::arrow::FileReader::GetRecordBatchReader()`.
 ([#44784](https://github.com/apache/arrow/issues/44784),
 [#44808](https://github.com/apache/arrow/issues/44808))
 
@@ -143,17 +144,21 @@ and `parquet::arrow::FileReader::GetRecordBatchReader()`.
 ## Java, Go, and Rust Notes
 
 The Java, Go, and Rust Go projects have moved to separate repositories outside
-the main Arrow monorepo.
+the main Arrow [monorepo](https://github.com/apache/arrow).
 
-- For notes on the latest release of the [Java implementation](https://github.com/apache/arrow-java), see the
-latest [Arrow Java changelog][7].
-- For notes on the latest release of the [Rust implementation](https://github.com/apache/arrow-rs) see the latest [Arrow Rust changelog][5].
-- For notes on the
-latest release of the [Go implementation](https://github.com/apache/arrow-go), see the latest [Arrow Go changelog][6]
+- For notes on the latest release of the [Java
+implementation](https://github.com/apache/arrow-java), see the latest [Arrow
+Java changelog][7].
+- For notes on the latest release of the [Rust
+  implementation](https://github.com/apache/arrow-rs) see the latest [Arrow Rust
+  changelog][5].
+- For notes on the latest release of the [Go
+implementation](https://github.com/apache/arrow-go), see the latest [Arrow Go
+changelog][6].
 
 ## Linux Packaging Notes
 
-- Debian: Fixed keyring format to support newer libapt (e.g., that used by
+- Debian: Fixed keyring format to support newer libapt (e.g., used by
   Trixie). ([#45118](https://github.com/apache/arrow/issues/45118))
 
 ## Python Notes
@@ -162,8 +167,8 @@ New features:
 
 - The upcoming pandas 3.0 [string
   dtype](https://pandas.pydata.org/pdeps/0014-string-dtype.html) is now
-  supported by PyArrow's `to_pandas` routine. In the future, when using pandas
-  >= 3.0, the new pandas behavior will be enabled by default. You can opt into
+  supported by PyArrow's `to_pandas` routine. In the future, when using pandas >=3.0,
+  the new pandas behavior will be enabled by default. You can opt into
   the new behavior under pandas >=2.3 by setting `pd.options.future.infer_string
   = True`. This may be considered a breaking change.
   ([#43683](https://github.com/apache/arrow/issues/43683))
@@ -185,8 +190,8 @@ Other improvements:
   view type. ([#45175](https://github.com/apache/arrow/issues/45175))
 - `from_buffers` is updated to work with `StringView`.
   ([#44651](https://github.com/apache/arrow/issues/44651))
-- Version suffixes are also set for Arrow Python C++ (`libarrow_python*`).
-  libraries ([#44614](https://github.com/apache/arrow/issues/44614))
+- Version suffixes are also set for Arrow Python C++ (`libarrow_python*`)
+  libraries. ([#44614](https://github.com/apache/arrow/issues/44614))
 
 ## Ruby and C GLib Notes
 
@@ -208,8 +213,8 @@ Other improvements:
 ### C GLib
 
 - Added support for 32bit and 64bit decimal, binary view, and string view. See
-  [issues
-  listed in the 19.0.0 milestone](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
+  [issues listed in the 19.0.0
+  milestone](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
   for more details.
 
 [1]: https://github.com/apache/arrow/milestone/66?closed=1

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -48,7 +48,8 @@ TODO
 
 ## Arrow Flight RPC notes
 
-TODO
+- The precision of a Timestamp (used for timeouts) is now nanoseconds on all platforms; previously it was platform-dependent. ([#44679](https://github.com/apache/arrow/issues/44679))
+- The Python bindings now support various new fields that were added to FlightEndpoint/FlightInfo (like `expiration_time`). ([#36954](https://github.com/apache/arrow/issues/36954))
 
 ## C++ notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -47,7 +47,7 @@ Thanks for your contributions and participation in the project!
 A [bug](https://github.com/apache/arrow/issues/45283) has been identified in the
 19.0.0 versions of the C++ and Python libraries which prevents reading Parquet
 files written by Arrow Rust v53.0.0 or higher. The files written by Arrow Rust
-are correct and the bug was in the patch adding support for Parquet's new
+are correct and the bug was in the patch adding support for Parquet's
 [SizeStatistics](https://github.com/apache/parquet-format/pull/197) feature to
 Arrow C++ and Python. See [#45293](https://github.com/apache/arrow/issues/45283)
 for more details including a potential workaround.

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -234,6 +234,6 @@ Other improvements:
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors
 [3]: {{ site.baseurl }}/release/19.0.0.html#changelog
 [4]: {{ site.baseurl }}/docs/r/news/
-[5]: https://github.com/apache/arrow-rs/releases
+[5]: https://github.com/apache/arrow-rs/blob/main/CHANGELOG.md
 [6]: https://github.com/apache/arrow-go/releases
 [7]: https://github.com/apache/arrow-java/releases

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -64,6 +64,12 @@ accuracy when the input value is close to 0 (GH-44903).
 Hyperbolic trigonometric functions and their reciprocals have also been added
 (GH-44952).
 
+### Acero
+
+Added AVX2 support for decoding row tables in the Swiss join specialization of
+hash joins, enabling up to 40% performance improvement for build-heavy workloads
+([GH-43693](https://github.com/apache/arrow/issues/43693)).
+
 ### Filesystems
 
 The S3 filesystem has gained support for server-side encryption with customer

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -98,7 +98,8 @@ disabled by default when writing (GH-40592).
 
 ## C# notes
 
-TODO
+* The `PrimitiveArrayBuilder` constructor has been made public to allow writing custom builders ([#23995](https://github.com/apache/arrow/issues/23995))
+* Improved the performance of looking up schema fields by name ([#44575](https://github.com/apache/arrow/issues/44575))
 
 ## Java notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -162,7 +162,8 @@ implementation, see the latest [Arrow Go changelog][6]
 
 ## Linux packages notes
 
-TODO
+- Enabled Azure file system
+- deb: Fixed keyring format for newer libapt
 
 [1]: https://github.com/apache/arrow/milestone/66?closed=1
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -62,7 +62,8 @@ libraries.
 ## Arrow Flight RPC Notes
 
 The precision of a Timestamp (used for timeouts) is now nanoseconds on all
-platforms; previously it was platform-dependent.
+platforms; previously it was platform-dependent. This may be a breaking change
+depending on your use case.
 ([#44679](https://github.com/apache/arrow/issues/44679))
 
 The Python bindings now support various new fields that were added to

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -212,7 +212,6 @@ Other improvements:
   listed in the 19.0.0 milestone](https://github.com/apache/arrow/issues?q=is%3Aclosed%20milestone%3A19.0.0%20label%3A%22Component%3A%20GLib%22)
   for more details.
 
-
 [1]: https://github.com/apache/arrow/milestone/66?closed=1
 [2]: {{ site.baseurl }}/release/19.0.0.html#contributors
 [3]: {{ site.baseurl }}/release/19.0.0.html#changelog

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -75,6 +75,10 @@ accuracy when the input value is close to 0 (GH-44903).
 Hyperbolic trigonometric functions and their reciprocals have also been added
 (GH-44952).
 
+The new Decimal32 and Decimal64 types have been further supported by allowing
+casting between numeric, string, and other decimal types
+([GH-43956](https://github.com/apache/arrow/issues/43956)).
+
 ### Acero
 
 Added AVX2 support for decoding row tables in the Swiss join specialization of

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -157,7 +157,20 @@ latest release of the [Go implementation](https://github.com/apache/arrow-go), s
 
 ## Python Notes
 
-TODO
+New features:
+
+* Support for 32-bit and 64-bit decimal types was added [GH-44713](https://github.com/apache/arrow/issues/44713)
+* Pandas 3.0 default string dtype is supported [GH-43683](https://github.com/apache/arrow/issues/43683)
+* Arrow PyCapsule stream objects are supported in `write_dataset` [GH-43410](https://github.com/apache/arrow/issues/43410)
+* New Flight features have been exposed [GH-36954](https://github.com/apache/arrow/issues/36954)
+* Bindings for `JsonExtensionType` and `JsonArray` are added [GH-44066](https://github.com/apache/arrow/issues/44066)
+* Hyperbolic trigonometry functions added to the Arrow C++ compute kernels are also available in PyArrow [GH-44952](https://github.com/apache/arrow/issues/44952)
+
+Other improvements:
+
+* `strings_to_categorical` keyword in `to_pandas` can now be used for string view type also [GH-45175](https://github.com/apache/arrow/issues/45175)
+* from_buffers is updated to work with` StringView` GH-44651 https://github.com/apache/arrow/issues/44651
+* Version suffixes are also set for Arrow Python C++ (libarrow_python*) libraries [GH-44614](https://github.com/apache/arrow/issues/44614)
 
 ## Ruby and C GLib Notes
 

--- a/_posts/2025-01-16-19.0.0-release.md
+++ b/_posts/2025-01-16-19.0.0-release.md
@@ -52,37 +52,49 @@ TODO
 
 ## C++ notes
 
-TODO
-
-### Acero
-
-TODO
-
 ### Compute
 
-TODO
+It is now possible to cast from a struct type to another struct type with
+additional columns, provided the additional columns are nullable (GH-44555).
 
-### Dataset
+The compute function `expm1` has been added to compute `exp(x) - 1` with better
+accuracy when the input value is close to 0 (GH-44903).
 
+Hyperbolic trigonometric functions and their reciprocals have also been added
+(GH-44952).
 
 ### Filesystems
 
-TODO
+The S3 filesystem has gained support for server-side encryption with customer
+provided keys, aka SSE-C (GH-43535).
 
-### Gandiva
+The S3 filesystem also gained an option to disable the SIGPIPE signals that may
+be emitted on some network events (GH-44695).
 
-TODO
+The Azure filesystem now supports SAS token authentication (GH-44308).
 
-### GPU
+### Flight RPC
 
+The UCX backend has been deprecated and is scheduled for removal (GH-45079).
 
-### IPC
+### Memory management
 
-TODO
+Mimalloc is now the default allocator, while jemalloc is disabled by default
+due to reports of compatibility issues on various platforms (GH-44976). While
+we do not expect this to cause any functional regression, it may lead to different
+memory consumption and performance characteristics in memory-intensive workloads.
 
 ### Parquet
 
-TODO
+The initial footer read size can now be configured to reduce the number of
+potential roundtrips on high-latency filesystems such as S3 (GH-45015).
+
+The new SizeStatistics format feature has been implemented, though it is
+disabled by default when writing (GH-40592).
+
+### Miscellaneous
+
+`ChunkResolver` is now exposed as a public API (GH-34535).
 
 ## C# notes
 


### PR DESCRIPTION
The 19.0.0 release isn't completely ready to be announced yet but I wanted to get a start on the blog post. Will tag people here to contribute to sections.

See the [19.0.0 release milestone](https://github.com/apache/arrow/milestone/66?closed=1) for commits in this release.