### PR TITLE
[Website] Add blog post for Arrow 19.0.1

### DIFF
--- a/_posts/2025-02-15-19.0.1-release.md
+++ b/_posts/2025-02-15-19.0.1-release.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: "Apache Arrow 19.0.1 Release"
+date: "2025-02-15 00:00:00"
+author: pmc
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+
+The Apache Arrow team is pleased to announce the 19.0.1 release.
+This is primary meant to address
+
+
+ ...TODO...
+
+
+mostly a bugfix release that includes [**12 resolved issues**][1]
+from [**00000 distinct contributors**][2]. See the Install Page to learn how to
+get the libraries for your platform.
+
+The release notes below are not exhaustive and only expose selected highlights
+of the release. Other bugfixes and improvements have been made: we refer
+you to the [complete changelog][3].
+
+## C++ notes
+
+TODO
+
+## Python notes
+
+TODO
+
+
+
+[1]: https://github.com/apache/arrow/milestone/68?closed=1
+[2]: {{ site.baseurl }}/release/19.0.1.html#contributors
+[3]: {{ site.baseurl }}/release/19.0.1.html#changelog

--- a/_posts/2025-02-16-19.0.1-release.md
+++ b/_posts/2025-02-16-19.0.1-release.md
@@ -41,6 +41,9 @@ you to the [complete changelog][3].
 
 ## C++ notes
 
+- A bug has been fixed which caused reading of Parquet files written by Arrow Rust v53.0.0 or higher to always fail [(#45283)](https://github.com/apache/arrow/issues/45283).
+- A workaround has been added to increase compatibility with newer versions of the AWS C++ SDK ([#45304](https://github.com/apache/arrow/issues/45304)).
+- An overflow bug has been fixed which could cause segmentation faults when joining inputs over a certain size ([#44513](https://github.com/apache/arrow/issues/44513)).
 ## Python notes
 
 - A bug has been fixed on the integration with Pandas when using `future.infer_string=True` for Pandas 2.2 ([#45296](https://github.com/apache/arrow/issues/45296)).

--- a/_posts/2025-02-16-19.0.1-release.md
+++ b/_posts/2025-02-16-19.0.1-release.md
@@ -43,6 +43,8 @@ you to the [complete changelog][3].
 
 ## Python notes
 
+- A bug has been fixed on the integration with Pandas when using `future.infer_string=True` for Pandas 2.2 ([#45296](https://github.com/apache/arrow/issues/45296)).
+
 [1]: https://github.com/apache/arrow/milestone/68?closed=1
 [2]: {{ site.baseurl }}/release/19.0.1.html#contributors
 [3]: {{ site.baseurl }}/release/19.0.1.html#changelog

--- a/_posts/2025-02-16-19.0.1-release.md
+++ b/_posts/2025-02-16-19.0.1-release.md
@@ -32,21 +32,29 @@ Parquet files created by Arrow Rust v53.0.0 or more recent. See the [19.0.0
 release blog post][4] for more information.
 
 This release includes [**12 resolved issues**][1] from [**9 distinct
-contributors**][2]. See the [Install Page][5] to learn how to get the libraries for
-your platform.
+contributors**][2]. See the [Install Page][5] to learn how to get the libraries
+for your platform.
 
 The release notes below are not exhaustive and only expose selected highlights
-of the release. Other bugfixes and improvements have been made: we refer
-you to the [complete changelog][3].
+of the release. Other bugfixes and improvements have been made: we refer you to
+the [complete changelog][3].
 
 ## C++ notes
 
-- A bug has been fixed which caused reading of Parquet files written by Arrow Rust v53.0.0 or higher to always fail [(#45283)](https://github.com/apache/arrow/issues/45283).
-- A workaround has been added to increase compatibility with newer versions of the AWS C++ SDK ([#45304](https://github.com/apache/arrow/issues/45304)).
-- An overflow bug has been fixed which could cause segmentation faults when joining inputs over a certain size ([#44513](https://github.com/apache/arrow/issues/44513)).
+- A bug has been fixed which caused reading of Parquet files written by Arrow
+  Rust v53.0.0 or higher to always fail
+  [(#45283)](https://github.com/apache/arrow/issues/45283).
+- A workaround has been added to increase compatibility with newer versions of
+  the AWS C++ SDK ([#45304](https://github.com/apache/arrow/issues/45304)).
+- An overflow bug has been fixed which could cause segmentation faults when
+  joining inputs over a certain size
+  ([#44513](https://github.com/apache/arrow/issues/44513)).
+
 ## Python notes
 
-- A bug has been fixed on the integration with Pandas when using `future.infer_string=True` for Pandas 2.2 ([#45296](https://github.com/apache/arrow/issues/45296)).
+- A bug has been fixed on the integration with Pandas when using
+  `future.infer_string=True` for Pandas 2.2
+  ([#45296](https://github.com/apache/arrow/issues/45296)).
 
 [1]: https://github.com/apache/arrow/milestone/68?closed=1
 [2]: {{ site.baseurl }}/release/19.0.1.html#contributors

--- a/_posts/2025-02-16-19.0.1-release.md
+++ b/_posts/2025-02-16-19.0.1-release.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Apache Arrow 19.0.1 Release"
-date: "2025-02-15 00:00:00"
+date: "2025-02-16 00:00:00"
 author: pmc
 categories: [release]
 ---

--- a/_posts/2025-02-16-19.0.1-release.md
+++ b/_posts/2025-02-16-19.0.1-release.md
@@ -24,17 +24,16 @@ limitations under the License.
 {% endcomment %}
 -->
 
-
 The Apache Arrow team is pleased to announce the 19.0.1 release.
-This is primary meant to address
 
+This release primarily addresses a bug in the recent Arrow 19.0.0 release which
+prevents Arrow C++ and libraries binding it (e.g., Python, R) from reading
+Parquet files created by Arrow Rust v53.0.0 or more recent. See the [19.0.0
+release blog post][4] for more information.
 
- ...TODO...
-
-
-mostly a bugfix release that includes [**12 resolved issues**][1]
-from [**00000 distinct contributors**][2]. See the Install Page to learn how to
-get the libraries for your platform.
+This release includes [**12 resolved issues**][1] from [**9 distinct
+contributors**][2]. See the [Install Page][5] to learn how to get the libraries for
+your platform.
 
 The release notes below are not exhaustive and only expose selected highlights
 of the release. Other bugfixes and improvements have been made: we refer
@@ -42,14 +41,10 @@ you to the [complete changelog][3].
 
 ## C++ notes
 
-TODO
-
 ## Python notes
-
-TODO
-
-
 
 [1]: https://github.com/apache/arrow/milestone/68?closed=1
 [2]: {{ site.baseurl }}/release/19.0.1.html#contributors
 [3]: {{ site.baseurl }}/release/19.0.1.html#changelog
+[4]: {{ site.baseurl }}/blog/2025/01/16/19.0.0-release/
+[5]: {{ site.baseurl }}/install


### PR DESCRIPTION
Vote thread is still open, https://lists.apache.org/thread/3p0odso4hp6njtb7p7vyzzq0to68t6vx, but I'm just getting ahead of post-release tasks. This PR is currently a draft.