### PR TITLE
Revert addition of Content-Security-Policy meta tag

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -3,12 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="
-        default-src 'self';
-        connect-src 'self' https://api.github.com https://buttons.github.io;
-        style-src 'self' https://fonts.googleapis.com;
-        font-src 'self' https://fonts.gstatic.com;
-        img-src 'self' https://www.apache.org;">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above meta tags *must* come first in the head; any other head content must come *after* these tags -->
     {% if page.title %}


### PR DESCRIPTION
This reverts the addition of the  `<meta http-equiv="Content-Security-Policy" ...` element in #595 because it caused more errors than it fixed.

I will open a separate PR to try to implement a fix that doesn't cause more errors.