### PR TITLE
Try fix Content Security Policy errors (take 5)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,13 +26,12 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 Redirect permanent /ballista https://datafusion.apache.org/ballista
 
 # fix Safari Content Security Policy errors
-Header add Content-Security-Policy-Report-Only "default-src 'self' *.apache.org; \
- connect-src 'self' *.apache.org api.github.com; \
- font-src 'self' fonts.gstatic.com \
- style-src 'self' fonts.googleapis.com \
-   'sha256-88sV2hhBstoYcag54b2hPpN+Oei7wd2Roz3k+RXEAfk=' \
-   'sha256-B3D8HD6PV1HtGZ5Z3qkXsN6p/LAiwBn9jehRuPkMBhQ=' \
-   'sha256-qo7STIM1L/OgU9y0De47mqod1UZFLJfTn36bRC42rfA='; \
- script-src 'self' *.apache.org \
-   'sha256-zcLnLb0EtdHEeff3LAr93euk343CTrN0BMhlaeAD8yY=' \
-   'sha256-eeHr1PLkM55qPqkpxjBDHGtxfQf3RvEYoENHzN4IL0Q='"
+Header always set Content-Security-Policy "default-src 'self' data: blob: 'unsafe-inline' https://www.apachecon.com/ https://www.communityovercode.org/ https://analytics.apache.org/ https://*.apache.org/; \
+ connect-src 'self' https://*.apache.org/ https://api.github.com/; \
+ script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/; \
+ style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com/; \
+ frame-ancestors 'self'; \
+ frame-src 'self' data: blob:; \
+ img-src 'self' data: https://*.apache.org/; \
+ worker-src 'self' data: blob:; \
+ font-src 'self' https://fonts.gstatic.com/;"

--- a/.htaccess
+++ b/.htaccess
@@ -26,6 +26,7 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 Redirect permanent /ballista https://datafusion.apache.org/ballista
 
 # fix Safari Content Security Policy errors
+Header unset Content-Security-Policy
 Header always set Content-Security-Policy "default-src 'self' data: blob: 'unsafe-inline' https://www.apachecon.com/ https://www.communityovercode.org/ https://analytics.apache.org/ https://*.apache.org/; \
  connect-src 'self' https://*.apache.org/ https://api.github.com/; \
  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/; \


### PR DESCRIPTION
It appears that the previous attempts were not having the expected effect because the ASF is already setting a Content-Security-Policy header which this was not overriding. The header that the ASF is setting is:

```
default-src 'self' data: blob: 'unsafe-inline' https://www.apachecon.com/ https://www.communityovercode.org/ https://analytics.apache.org/;
script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/;
style-src 'self' 'unsafe-inline' data:;
frame-ancestors 'self';
frame-src 'self' data: blob:;
img-src 'self' data: https://*.apache.org/;
worker-src 'self' data: blob:;
```

This unsets the ASF-set CSP header and sets a new one that is based on the ASF one with additions.