### PR TITLE
Website: Support feed autodiscovery

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -84,4 +84,5 @@
     {% if jekyll.environment == 'production' %}
     {% include analytics.html %}
     {% endif %}
+    {% feed_meta %}
   </head>


### PR DESCRIPTION
As a follow-on to https://github.com/apache/arrow-site/pull/611, this adds a `link` tag to our head which should support feed autodiscovery.