### PR TITLE
Fix illustration for dict encoding in row format

### DIFF
--- a/_posts/2022-11-07-multi-column-sorts-in-arrow-rust-part-2.md
+++ b/_posts/2022-11-07-multi-column-sorts-in-arrow-rust-part-2.md
@@ -212,7 +212,7 @@ A null value is encoded as a single `0x00` byte, and a non-null value encoded as
 
 ```
                           ┌─────┬─────┬─────┬─────┐
-   "Fabulous"             │ 01  │ 03  │ 05  │ 00  │
+   "Fabulous"             │ 01  │ 01  │ 02  │ 00  │
                           └─────┴─────┴─────┴─────┘
 
                           ┌─────┬─────┬─────┐


### PR DESCRIPTION
As mentioned in the previous [comment](https://github.com/apache/arrow-rs/issues/4639#issuecomment-2705901229), the dictionary encoding example contains inaccuracies.