### PR TITLE
Update .htaccess file to allow kapa.ai bot to work

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -29,6 +29,6 @@ Redirect permanent /ballista https://datafusion.apache.org/ballista
 # See https://docs.kapa.ai/integrations/understanding-csp-cors
 <IfModule mod_headers.c>
     <Location /docs>
-        Header set Content-Security-Policy "script-src 'self' widget.kapa.ai www.google.com; connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai; frame-src 'self' www.google.com;"
+        Header set Content-Security-Policy-Report-Only "script-src 'self' widget.kapa.ai www.google.com; connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai; frame-src 'self' www.google.com;"
     </Location>
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -24,3 +24,9 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 
 # redirect all ballista URLs to new website
 Redirect permanent /ballista https://datafusion.apache.org/ballista
+
+# enable kapa.ai bot
+<IfModule mod_headers.c>
+    Header set Content-Security-Policy "script-src 'self' widget.kapa.ai www.google.com; connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai; frame-src 'self' www.google.com;"
+</IfModule>
+

--- a/.htaccess
+++ b/.htaccess
@@ -25,8 +25,10 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 # redirect all ballista URLs to new website
 Redirect permanent /ballista https://datafusion.apache.org/ballista
 
-# enable kapa.ai bot
+# enable kapa.ai bot (GH-45665)
+# See https://docs.kapa.ai/integrations/understanding-csp-cors
 <IfModule mod_headers.c>
-    Header set Content-Security-Policy "script-src 'self' widget.kapa.ai www.google.com; connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai; frame-src 'self' www.google.com;"
+    <Location /docs>
+        Header set Content-Security-Policy "script-src 'self' widget.kapa.ai www.google.com; connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai; frame-src 'self' www.google.com;"
+    </Location>
 </IfModule>
-


### PR DESCRIPTION
This PR updates the .htaccess file to allow the kapa.ai bot to work correctly.  The [Infra guidance](https://infra.apache.org/csp.html) notes that external resources are disallowed for providers we **do not** have a DPA with, but kapa.ai **does** [have one with the ASF](https://privacy.apache.org/faq/committers.html) so this should be all good.