### PR TITLE
Revert addition to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -24,11 +24,3 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 
 # redirect all ballista URLs to new website
 Redirect permanent /ballista https://datafusion.apache.org/ballista
-
-# enable kapa.ai bot (GH-45665)
-# See https://docs.kapa.ai/integrations/understanding-csp-cors
-<IfModule mod_headers.c>
-    <Location /docs>
-        Header set Content-Security-Policy-Report-Only "script-src 'self' widget.kapa.ai www.google.com; connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai; frame-src 'self' www.google.com;"
-    </Location>
-</IfModule>


### PR DESCRIPTION
This reverts #619. The Arrow site began to serve an HTTP 500 error some time after #619 was merged. Possibly this was a coincidence but I'm quickly merging this revert to see if that brings the site back up.