### PR TITLE
Update .htaccess to allow kapa.ai bot

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -24,3 +24,11 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 
 # redirect all ballista URLs to new website
 Redirect permanent /ballista https://datafusion.apache.org/ballista
+
+# enable kapa.ai bot (GH-45665)
+# See https://docs.kapa.ai/integrations/understanding-csp-cors and https://issues.apache.org/jira/browse/INFRA-26638
+<IfModule mod_headers.c>
+    <Location /docs>
+        Header set Content-Security-Policy "default-src 'self' data: blob: 'unsafe-inline' https://www.apachecon.com/ https://www.communityovercode.org/ https://analytics.apache.org/; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/ https://www.apachecon.com/ https://*.kapa.ai/; style-src 'self' 'unsafe-inline' https://*.kapa.ai/ data:; frame-ancestors 'self'; frame-src 'self' data: blob:; img-src 'self' data: https://*.apache.org/ https://www.apachecon.com/ https://*.kapa.ai/; worker-src 'self' data: blob:;"
+    </Location>
+</IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -28,7 +28,5 @@ Redirect permanent /ballista https://datafusion.apache.org/ballista
 # enable kapa.ai bot (GH-45665)
 # See https://docs.kapa.ai/integrations/understanding-csp-cors and https://issues.apache.org/jira/browse/INFRA-26638
 <IfModule mod_headers.c>
-    <Location /docs>
         Header set Content-Security-Policy "default-src 'self' data: blob: 'unsafe-inline' https://www.apachecon.com/ https://www.communityovercode.org/ https://analytics.apache.org/; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/ https://www.apachecon.com/ https://*.kapa.ai/; style-src 'self' 'unsafe-inline' https://*.kapa.ai/ data:; frame-ancestors 'self'; frame-src 'self' data: blob:; img-src 'self' data: https://*.apache.org/ https://www.apachecon.com/ https://*.kapa.ai/; worker-src 'self' data: blob:;"
-    </Location>
 </IfModule>


### PR DESCRIPTION
Enabling the kapa.ai bot, this time using an Infra-suggested CSP update (see https://issues.apache.org/jira/browse/INFRA-26638).
