### PR TITLE
[Website] Replace Xitter with BlueSky

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,8 +60,6 @@ title: "Apache Arrow"
 description: "Apache Arrow is the universal columnar format and multi-language toolbox for fast data interchange and in-memory analytics. It specifies a standardized language-independent column-oriented memory format for flat and nested data, organized for efficient analytic operations on modern hardware. It also provides computational libraries and zero-copy streaming messaging and interprocess communication. Languages currently supported include C, C++, C#, Go, Java, JavaScript, MATLAB, Python, R, Ruby, and Rust."
 url: https://arrow.apache.org
 logo: /img/logo.png
-twitter:
-  username: ApacheArrow
 defaults:
   - scope:
       path: ""

--- a/_includes/socials.html
+++ b/_includes/socials.html
@@ -41,9 +41,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <div class="widget widget-lg"><a class="btn" href="https://www.linkedin.com/company/apache-arrow/" rel="noopener" target="_blank" aria-label="Follow Apache Arrow on LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" role="img" aria-hidden="true"><path d="M14.5455 0H1.45455C0.650909 0 0 0.650909 0 1.45455V14.5455C0 15.3491 0.650909 16 1.45455 16H14.5455C15.3491 16 16 15.3491 16 14.5455V1.45455C16 0.650909 15.3491 0 14.5455 0ZM5.05746 13.0909H2.912V6.18764H5.05746V13.0909ZM3.96291 5.20073C3.27127 5.20073 2.712 4.64 2.712 3.94982C2.712 3.25964 3.272 2.69964 3.96291 2.69964C4.65236 2.69964 5.21309 3.26036 5.21309 3.94982C5.21309 4.64 4.65236 5.20073 3.96291 5.20073ZM13.0938 13.0909H10.9498V9.73382C10.9498 8.93309 10.9353 7.90327 9.83491 7.90327C8.71855 7.90327 8.54691 8.77527 8.54691 9.67564V13.0909H6.40291V6.18764H8.46109V7.13091H8.49018C8.77673 6.58836 9.47636 6.016 10.52 6.016C12.6924 6.016 13.0938 7.44582 13.0938 9.30473V13.0909V13.0909Z" fill="#000"></path></svg>&nbsp;<span>Follow</span></a></div>
     </span>
   </div>
-  <div class="custom-social-badge"> <!-- X -->
+  <div class="custom-social-badge"> <!-- BlueSky -->
     <span>
-      <div class="widget widget-lg"><a class="btn" href="https://x.com/ApacheArrow" rel="noopener" target="_blank" aria-label="Follow Apache Arrow on X"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16" role="img" aria-hidden="true"><path fill="#000" d="M9.332 6.925 14.544 1h-1.235L8.783 6.145 5.17 1H1l5.466 7.78L1 14.993h1.235l4.78-5.433 3.816 5.433H15L9.332 6.925ZM7.64 8.848l-.554-.775L2.68 1.91h1.897l3.556 4.975.554.775 4.622 6.466h-1.897L7.64 8.848Z"></path></svg>&nbsp;<span>Follow</span></a></div>
+      <div class="widget widget-lg"><a class="btn" href="https://bsky.app/profile/arrow.apache.org" rel="noopener" target="_blank" aria-label="Follow Apache Arrow on BlueSky">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16" role="img" aria-hidden="true">
+          <path fill="#000" d="M407.8 294.7c-3.3-.4-6.7-.8-10-1.3c3.4 .4 6.7 .9 10 1.3zM288 227.1C261.9 176.4 190.9 81.9 124.9 35.3C61.6-9.4 37.5-1.7 21.6 5.5C3.3 13.8 0 41.9 0 58.4S9.1 194 15 213.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3 .5-6.6 1-10 1.4C74.3 308.6-9.1 342.8 100.3 464.5C220.6 589.1 265.1 437.8 288 361.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4 .4 6.7 .9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7C566.9 194 576 75 576 58.4s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8C385.1 81.9 314.1 176.4 288 227.1z"/>
+        </svg>
+        &nbsp;<span>Follow</span>
+      </a>
+    </div>
     </span>
   </div>
 </div>


### PR DESCRIPTION
Fixes #649.

Move from Xitter profile to BlueSky. See also https://github.com/apache/arrow/issues/46376.