### PR TITLE
post: Fix a markup in Apache Arrow Java 18.3.0

### DIFF
--- a/_posts/2025-05-13-arrow-java-18.3.0.md
+++ b/_posts/2025-05-13-arrow-java-18.3.0.md
@@ -39,6 +39,7 @@ This is a minor release since the last release [v18.2.0](https://github.com/apac
 * GH-698: Improve and fix Avro read consumers by @martin-traverse in [#718](https://github.com/apache/arrow-java/pull/718)
 * GH-737: [FlightSQL] Allow returning column remarks in FlightSQL's CommandGetTables by @mateuszrzeszutek in [#727](https://github.com/apache/arrow-java/pull/727)
 * GH-661: [Flight] JDBC: Cache failed locations by @lidavidm in [#662](https://github.com/apache/arrow-java/pull/662)
+
 ### Bug Fixes
 * GH-601: [Gandiva] Synchronize some methods on the Projector by @lriggs in [#602](https://github.com/apache/arrow-java/pull/602)
 * GH-625: Map MinorType getNewFieldWriter returns UnionMapWriter by @wsuppiger in [#627](https://github.com/apache/arrow-java/pull/627)


### PR DESCRIPTION
We need an empty line between a list markup and a section markup to avoid putting a section into a list.