### PR TITLE
Update Swift links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -45,7 +45,7 @@
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/r">R</a>
             <a class="dropdown-item" href="https://github.com/apache/arrow/blob/main/ruby/README.md">Ruby</a>
             <a class="dropdown-item" href="https://docs.rs/arrow/latest">Rust</a>
-            <a class="dropdown-item" href="{{ site.baseurl }}/docs/swift">Swift</a>
+            <a class="dropdown-item" href="{{ site.baseurl }}/swift">Swift</a>
           </div>
         </li>
         <li class="nav-item dropdown">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -45,7 +45,7 @@
             <a class="dropdown-item" href="{{ site.baseurl }}/docs/r">R</a>
             <a class="dropdown-item" href="https://github.com/apache/arrow/blob/main/ruby/README.md">Ruby</a>
             <a class="dropdown-item" href="https://docs.rs/arrow/latest">Rust</a>
-            <a class="dropdown-item" href="https://github.com/apache/arrow/blob/main/swift/Arrow/README.md">Swift</a>
+            <a class="dropdown-item" href="{{ site.baseurl }}/docs/swift">Swift</a>
           </div>
         </li>
         <li class="nav-item dropdown">
@@ -69,7 +69,7 @@
             <a class="dropdown-item" href="https://github.com/apache/arrow/tree/main/r">R</a>
             <a class="dropdown-item" href="https://github.com/apache/arrow/tree/main/ruby">Ruby</a>
             <a class="dropdown-item" href="https://github.com/apache/arrow-rs">Rust</a>
-            <a class="dropdown-item" href="https://github.com/apache/arrow/tree/main/swift">Swift</a>
+            <a class="dropdown-item" href="https://github.com/apache/arrow-swift">Swift</a>
           </div>
         </li>
         <li class="nav-item dropdown">


### PR DESCRIPTION
It is necessary to update Swift URL due to move the repository.
https://github.com/apache/arrow/pull/46804

This PR wait  to resolve   https://github.com/apache/arrow-swift/issues/9 issue.
Because http://arrow.apache.org/docs/swift/ not available yet.
