### PR TITLE
[Website] Remove "Apache Arrow" from header in 18.1.0 release note

### DIFF
--- a/_release/18.1.0.md
+++ b/_release/18.1.0.md
@@ -72,8 +72,6 @@ $ git shortlog -sn --group=trailer:signed-off-by apache-arrow-18.0.0..apache-arr
 
 ## Changelog
 
-# 18.1.0 (2024-11-24)
-
 ## Bug Fixes
 
 * [GH-44360](https://github.com/apache/arrow/issues/44360) - [C#] Fix Flight DoExchange incompatibility with C++ implementation (#44424)


### PR DESCRIPTION
I'm not sure how this got in the 18.1.0 release note but it breaks the post-04-website.sh script.

See https://github.com/apache/arrow-site/pull/669.