### PR TITLE
[Website] Always open external links with target=_blank

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,5 @@ group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jekyll-jupyter-notebook"
   gem "jekyll-seo-tag"
+  gem "jekyll-target-blank"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -73,3 +73,9 @@ defaults:
 
 plugins:
   - jekyll-feed
+  - jekyll-target-blank
+
+# We want noopener to support older browsers but don't want noreferrer
+# See https://github.com/apache/arrow-site/issues/677
+target-blank:
+   noreferrer: false


### PR DESCRIPTION
Makes link opening behavior consistent for internal and external links. Internal links work as before and now external links (any non-relative URL) have `target="_blank" rel="noopener"` set. Content authors can override this by using inline HTML.

Closes https://github.com/apache/arrow-site/issues/677