### PR TITLE
Add UNSAFE option to Jekyll config to allow raw HTML

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ markdown: CommonMark
 commonmark:
   options:
     - FOOTNOTES
+    - UNSAFE
   extensions:
     - autolink
     - strikethrough


### PR DESCRIPTION
Fixes GH-680.

We need `UNSAFE` option for raw `<table>`.