### PR TITLE
Avoid needless asf-site update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,9 @@ jobs:
           cd asf-site
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if [ "$(git status --porcelain)" != "" ]; then
+          # Ignore feed.xml changes because feed.xml always has a change.
+          # feed.xml uses the current time. So feed.xml is always different.
+          if [ "$(git status --porcelain | grep -v feed.xml)" != "" ]; then
             # There are changes to the built site
             git add --all
             git commit -m "Updating built site"

--- a/_release/0.1.0.md
+++ b/_release/0.1.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: 0.1.0 Release
+date: "2016-10-10"
 permalink: /release/0.1.0.html
 ---
 <!--

--- a/_release/0.10.0.md
+++ b/_release/0.10.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.10.0 Release
+date: "2018-08-06"
 permalink: /release/0.10.0.html
 ---
 <!--

--- a/_release/0.11.0.md
+++ b/_release/0.11.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.11.0 Release
+date: "2018-10-08"
 permalink: /release/0.11.0.html
 ---
 <!--

--- a/_release/0.11.1.md
+++ b/_release/0.11.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.11.1 Release
+date: "2018-10-19"
 permalink: /release/0.11.1.html
 ---
 <!--

--- a/_release/0.12.0.md
+++ b/_release/0.12.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.12.0 Release
+date: "2019-01-20"
 permalink: /release/0.12.0.html
 ---
 <!--

--- a/_release/0.13.0.md
+++ b/_release/0.13.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.13.0 Release
+date: "2019-04-01"
 permalink: /release/0.13.0.html
 ---
 <!--

--- a/_release/0.14.0.md
+++ b/_release/0.14.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.14.0 Release
+date: "2019-07-04"
 permalink: /release/0.14.0.html
 ---
 <!--

--- a/_release/0.14.1.md
+++ b/_release/0.14.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.14.1 Release
+date: "2019-07-22"
 permalink: /release/0.14.1.html
 ---
 <!--

--- a/_release/0.15.0.md
+++ b/_release/0.15.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.15.0 Release
+date: "2019-10-05"
 permalink: /release/0.15.0.html
 ---
 <!--

--- a/_release/0.15.1.md
+++ b/_release/0.15.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.15.1 Release
+date: "2019-11-01"
 permalink: /release/0.15.1.html
 ---
 <!--

--- a/_release/0.16.0.md
+++ b/_release/0.16.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.16.0 Release
+date: "2020-02-07"
 permalink: /release/0.16.0.html
 ---
 <!--

--- a/_release/0.17.0.md
+++ b/_release/0.17.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.17.0 Release
+date: "2020-04-20"
 permalink: /release/0.17.0.html
 ---
 <!--

--- a/_release/0.17.1.md
+++ b/_release/0.17.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.17.1 Release
+date: "2020-05-18"
 permalink: /release/0.17.1.html
 ---
 <!--

--- a/_release/0.2.0.md
+++ b/_release/0.2.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: 0.2.0 Release
+date: "2017-02-18"
 permalink: /release/0.2.0.html
 ---
 <!--

--- a/_release/0.3.0.md
+++ b/_release/0.3.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: 0.3.0 Release
+date: "2017-05-05"
 permalink: /release/0.3.0.html
 ---
 <!--

--- a/_release/0.4.0.md
+++ b/_release/0.4.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: 0.4.0 Release
+date: "2017-05-22"
 permalink: /release/0.4.0.html
 ---
 <!--

--- a/_release/0.4.1.md
+++ b/_release/0.4.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: 0.4.1 Release
+date: "2017-06-09"
 permalink: /release/0.4.1.html
 ---
 <!--

--- a/_release/0.5.0.md
+++ b/_release/0.5.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.5.0 Release
+date: "2017-07-23"
 permalink: /release/0.5.0.html
 ---
 <!--

--- a/_release/0.6.0.md
+++ b/_release/0.6.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.6.0 Release
+date: "2017-08-14"
 permalink: /release/0.6.0.html
 ---
 <!--

--- a/_release/0.7.0.md
+++ b/_release/0.7.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.7.0 Release
+date: "2017-09-17"
 permalink: /release/0.7.0.html
 ---
 <!--

--- a/_release/0.7.1.md
+++ b/_release/0.7.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.7.1 Release
+date: "2017-10-01"
 permalink: /release/0.7.1.html
 ---
 <!--

--- a/_release/0.8.0.md
+++ b/_release/0.8.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.8.0 Release
+date: "2017-12-18"
 permalink: /release/0.8.0.html
 ---
 <!--

--- a/_release/0.9.0.md
+++ b/_release/0.9.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 0.9.0 Release
+date: "2018-03-21"
 permalink: /release/0.9.0.html
 ---
 <!--

--- a/_release/1.0.0.md
+++ b/_release/1.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 1.0.0 Release
+date: "2020-07-24"
 permalink: /release/1.0.0.html
 ---
 <!--

--- a/_release/1.0.1.md
+++ b/_release/1.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 1.0.1 Release
+date: "2020-08-21"
 permalink: /release/1.0.1.html
 ---
 <!--

--- a/_release/10.0.0.md
+++ b/_release/10.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 10.0.0 Release
+date: "2022-10-26"
 permalink: /release/10.0.0.html
 ---
 <!--

--- a/_release/10.0.1.md
+++ b/_release/10.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 10.0.1 Release
+date: "2022-11-22"
 permalink: /release/10.0.1.html
 ---
 <!--

--- a/_release/11.0.0.md
+++ b/_release/11.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 11.0.0 Release
+date: "2023-01-26"
 permalink: /release/11.0.0.html
 ---
 <!--

--- a/_release/12.0.0.md
+++ b/_release/12.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 12.0.0 Release
+date: "2023-05-02"
 permalink: /release/12.0.0.html
 ---
 <!--

--- a/_release/12.0.1.md
+++ b/_release/12.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 12.0.1 Release
+date: "2023-06-13"
 permalink: /release/12.0.1.html
 ---
 <!--

--- a/_release/13.0.0.md
+++ b/_release/13.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 13.0.0 Release
+date: "2023-08-23"
 permalink: /release/13.0.0.html
 ---
 <!--

--- a/_release/14.0.0.md
+++ b/_release/14.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 14.0.0 Release
+date: "2023-11-01"
 permalink: /release/14.0.0.html
 ---
 <!--

--- a/_release/14.0.1.md
+++ b/_release/14.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 14.0.1 Release
+date: "2023-11-10"
 permalink: /release/14.0.1.html
 ---
 <!--

--- a/_release/14.0.2.md
+++ b/_release/14.0.2.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 14.0.2 Release
+date: "2023-12-19"
 permalink: /release/14.0.2.html
 ---
 <!--

--- a/_release/15.0.0.md
+++ b/_release/15.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 15.0.0 Release
+date: "2024-01-21"
 permalink: /release/15.0.0.html
 ---
 <!--

--- a/_release/15.0.1.md
+++ b/_release/15.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 15.0.1 Release
+date: "2024-03-07"
 permalink: /release/15.0.1.html
 ---
 <!--

--- a/_release/15.0.2.md
+++ b/_release/15.0.2.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 15.0.2 Release
+date: "2024-03-18"
 permalink: /release/15.0.2.html
 ---
 <!--

--- a/_release/16.0.0.md
+++ b/_release/16.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 16.0.0 Release
+date: "2024-04-20"
 permalink: /release/16.0.0.html
 ---
 <!--

--- a/_release/16.1.0.md
+++ b/_release/16.1.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 16.1.0 Release
+date: "2024-05-14"
 permalink: /release/16.1.0.html
 ---
 <!--

--- a/_release/17.0.0.md
+++ b/_release/17.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 17.0.0 Release
+date: "2024-07-16"
 permalink: /release/17.0.0.html
 ---
 <!--

--- a/_release/18.0.0.md
+++ b/_release/18.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 18.0.0 Release
+date: "2024-10-28"
 permalink: /release/18.0.0.html
 ---
 <!--

--- a/_release/18.1.0.md
+++ b/_release/18.1.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 18.1.0 Release
+date: "2024-11-24"
 permalink: /release/18.1.0.html
 ---
 <!--

--- a/_release/19.0.0.md
+++ b/_release/19.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 19.0.0 Release
+date: "2025-01-16"
 permalink: /release/19.0.0.html
 ---
 <!--

--- a/_release/19.0.1.md
+++ b/_release/19.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 19.0.1 Release
+date: "2025-02-16"
 permalink: /release/19.0.1.html
 ---
 <!--

--- a/_release/2.0.0.md
+++ b/_release/2.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 2.0.0 Release
+date: "2020-10-19"
 permalink: /release/2.0.0.html
 ---
 <!--

--- a/_release/20.0.0.md
+++ b/_release/20.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 20.0.0 Release
+date: "2025-04-27"
 permalink: /release/20.0.0.html
 ---
 <!--

--- a/_release/21.0.0.md
+++ b/_release/21.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 21.0.0 Release
+date: "2025-07-17"
 permalink: /release/21.0.0.html
 ---
 <!--

--- a/_release/3.0.0.md
+++ b/_release/3.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 3.0.0 Release
+date: "2021-01-26"
 permalink: /release/3.0.0.html
 ---
 <!--

--- a/_release/4.0.0.md
+++ b/_release/4.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 4.0.0 Release
+date: "2021-04-26"
 permalink: /release/4.0.0.html
 ---
 <!--

--- a/_release/4.0.1.md
+++ b/_release/4.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 4.0.1 Release
+date: "2021-05-26"
 permalink: /release/4.0.1.html
 ---
 <!--

--- a/_release/5.0.0.md
+++ b/_release/5.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 5.0.0 Release
+date: "2021-07-29"
 permalink: /release/5.0.0.html
 ---
 <!--

--- a/_release/6.0.0.md
+++ b/_release/6.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 6.0.0 Release
+date: "2021-10-26"
 permalink: /release/6.0.0.html
 ---
 <!--

--- a/_release/6.0.1.md
+++ b/_release/6.0.1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 6.0.1 Release
+date: "2021-11-18"
 permalink: /release/6.0.1.html
 ---
 <!--

--- a/_release/7.0.0.md
+++ b/_release/7.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 7.0.0 Release
+date: "2022-02-03"
 permalink: /release/7.0.0.html
 ---
 <!--

--- a/_release/8.0.0.md
+++ b/_release/8.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 8.0.0 Release
+date: "2022-05-06"
 permalink: /release/8.0.0.html
 ---
 <!--

--- a/_release/9.0.0.md
+++ b/_release/9.0.0.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Apache Arrow 9.0.0 Release
+date: "2022-08-03"
 permalink: /release/9.0.0.html
 ---
 <!--

--- a/_release/index.md
+++ b/_release/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Releases
+date: "2025-07-17"
 permalink: /release/index.html
 ---
 <!--


### PR DESCRIPTION
Fixes GH-689

* Ignore feed.xml changes because feed.xml is always changed
  * feed.xml uses the current time
* Specify `date: ` explicitly in `_release/*.md`
  * We can use release date for `date: ` except `_release/index.md`
  * We can use the latest release's release date for `date: ` for `_release/index.md`