### PR TITLE
GH-695: [Website] Fix anchors on visual identity page

### DIFF
--- a/visual_identity.md
+++ b/visual_identity.md
@@ -32,7 +32,9 @@ As a community project, the visual identity guidelines for Apache Arrow attempt 
 - [Usage guidelines](#using-the-logo)
 - [List of logo files](#files)
 
-## Design of the logo {#design}
+<a name="design">
+
+## Design of the logo
 
 The Apache Arrow logo consists of the "Apache Arrow" logotype and the "Triple Chevron" logomark, arranged horizontally with the text placed to the left of the image. The standard "light theme" version of the logo uses black text and image against a white background, and the standard "dark theme" version of the logo is white against a black background. The light version looks like this:
 
@@ -56,7 +58,9 @@ A good example of when the vertical layout is more appropriate is in the context
 
 <div class="col-8 offset-2 py-1"><img src="{{ site.baseurl }}/img/logo-spacing-hex.png" width="100%"></div>
 
-## Variations of the logo {#variations}
+<a name="variations">
+
+## Variations of the logo
 
 At the bottom of this page you can find the complete list of all logo-related files provided by the Apache Arrow project. The logo exists in a light theme and a dark theme, and these versions are usually simple inversions of one another. The light theme uses black text against a white (or other light colored) background:
 
@@ -104,7 +108,9 @@ and the "Apache Arrow" logotype on its own:
 </div>
 </div>
 
-## Using the Apache Arrow logos {#using-the-logo}
+<a name="using-the-logo">
+
+## Using the Apache Arrow logos
 
 ### General guidelines
 
@@ -136,7 +142,9 @@ The image on the right adds extra orange colored chevrons to the dark themed hex
 
 Many other context-appropriate informal variations can be imagined. For example, if Apache Arrow were being used to power a generative art system, the background fill to the logo might not be a solid color, it could be the art itself. Again, the overriding principle is that the visual integrity of the Apache Arrow logo remains intact and the modifications are appropriate to the context in which it is used.
 
-## List of provided logo files {#files}
+<a name="files">
+
+## List of provided logo files
 
 ### Horizontal logos
 

--- a/visual_identity.md
+++ b/visual_identity.md
@@ -32,7 +32,7 @@ As a community project, the visual identity guidelines for Apache Arrow attempt 
 - [Usage guidelines](#using-the-logo)
 - [List of logo files](#files)
 
-<a name="design">
+<a name="design"></a>
 
 ## Design of the logo
 
@@ -58,7 +58,7 @@ A good example of when the vertical layout is more appropriate is in the context
 
 <div class="col-8 offset-2 py-1"><img src="{{ site.baseurl }}/img/logo-spacing-hex.png" width="100%"></div>
 
-<a name="variations">
+<a name="variations"></a>
 
 ## Variations of the logo
 
@@ -108,7 +108,7 @@ and the "Apache Arrow" logotype on its own:
 </div>
 </div>
 
-<a name="using-the-logo">
+<a name="using-the-logo"></a>
 
 ## Using the Apache Arrow logos
 
@@ -142,7 +142,7 @@ The image on the right adds extra orange colored chevrons to the dark themed hex
 
 Many other context-appropriate informal variations can be imagined. For example, if Apache Arrow were being used to power a generative art system, the background fill to the logo might not be a solid color, it could be the art itself. Again, the overriding principle is that the visual integrity of the Apache Arrow logo remains intact and the modifications are appropriate to the context in which it is used.
 
-<a name="files">
+<a name="files"></a>
 
 ## List of provided logo files
 


### PR DESCRIPTION
I think the recent markdown parser change made it so we can't do headers like this anymore,

```
# Design of the logo {#design}
```

This fixes the [current rendering](https://arrow.apache.org/visual_identity/) which has headers that look like this:

> Design of the logo {#design}

and restores the internal document anchors. A better solution might be to look into a Jekyll plugin that automatically enables anchors on headers and ToCs.

Closes #695 