### PR TITLE
Fix fonts in preview pages in forks

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -27,7 +27,7 @@ body {
   font-family: Lato;
   font-style: normal;
   font-weight: 400;
-  src: url('/assets/fonts/lato-v24-latin-regular.woff2') format('woff2');
+  src: url('../assets/fonts/lato-v24-latin-regular.woff2') format('woff2');
 }
 
 @font-face {
@@ -35,7 +35,7 @@ body {
   font-family: Lato;
   font-style: italic;
   font-weight: 400;
-  src: url('/assets/fonts/lato-v24-latin-italic.woff2') format('woff2');
+  src: url('../assets/fonts/lato-v24-latin-italic.woff2') format('woff2');
 }
 
 .footer {


### PR DESCRIPTION
The base URL of preview sites isn't the top of the domain, so these font files were not loading. This fixes it without causing any problems on the main deployed site.