### PR TITLE
Website: Add blog post for 22.0.0

### DIFF
--- a/_posts/2025-10-24-22.0.0-release.md
+++ b/_posts/2025-10-24-22.0.0-release.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Apache Arrow 22.0.0 Release"
-date: "2025-09-24 00:00:00"
+date: "2025-10-24 00:00:00"
 author: pmc
 categories: [release]
 ---
@@ -150,9 +150,9 @@ Relevant bug fixes:
 - `FileSystem.from_uri` is reverted to be a staticmethod again ([GH-47179](https://github.com/apache/arrow/issues/47179)).
 
 
-## Java, JavaScript, Go, .NET and Rust Notes
+## Java, JavaScript, Go, .NET, Swift and Rust Notes
 
-The Java, JavaScript, Go, .NET and Rust projects have moved to separate
+The Java, JavaScript, Go, .NET, Swift and Rust projects have moved to separate
 repositories outside the main Arrow [monorepo](https://github.com/apache/arrow).
 
 - For notes on the latest release of the [Java
@@ -168,8 +168,8 @@ JavaScript changelog][8].
 implementation](https://github.com/apache/arrow-go), see the latest [Arrow Go
 changelog][6].
 - For notes on the latest release of the [.NET
-implementation](https://github.com/apache/arrow-dotnet), see the latest [Arrow 
-changelog][9].
+implementation](https://github.com/apache/arrow-dotnet), see the latest [Arrow  .NET changelog][9].
+- For notes on the latest release of the [Swift implementation](https://github.com/apache/arrow-swift), see the latest [Arrow Swift changelog][10].
 
 [1]: https://github.com/apache/arrow/milestone/70?closed=1
 [2]: {{ site.baseurl }}/release/22.0.0.html#contributors
@@ -180,3 +180,4 @@ changelog][9].
 [7]: <https://github.com/apache/arrow-java/releases>
 [8]: <https://github.com/apache/arrow-js/releases>
 [9]: <https://github.com/apache/arrow-dotnet/releases>
+[10]: <https://github.com/apache/arrow-swift/releases>


### PR DESCRIPTION
Release blog post for 22.0.0.

Issues on the milestone are here: https://github.com/apache/arrow/milestone/70
