### PR TITLE
[Website]: List Kyle Barron as committer

### DIFF
--- a/_data/committers.yml
+++ b/_data/committers.yml
@@ -372,6 +372,10 @@
   role: Committer
   alias: kevingurney
   affiliation: MathWorks
+- name: Kyle Barron
+  role: Committer
+  alias: kylebarron
+  affiliation: Development Seed
 - name: Laurent Goujon
   role: Committer
   alias: laurent


### PR DESCRIPTION
Add @kylebarron  's role on https://arrow.apache.org/committers/, per https://lists.apache.org/thread/xoy67b0s52y9s8t84dk3tbgypr2m926n

@kylebarron  I listed Development Seed as your affiliation based on https://kylebarron.dev/about but you can list whatever affiliation you prefer (e.g. Unaffiliated, etc)