### PR TITLE
Website: Add blog post for arrow-rs 57.0.0

### DIFF
--- a/_posts/2025-10-30-arrow-rs-57.0.0.md
+++ b/_posts/2025-10-30-arrow-rs-57.0.0.md
@@ -168,7 +168,7 @@ initiating the work
 [@liamzwbao]: https://github.com/liamzwbao
 [@codephage2020]: https://github.com/codephage2020
 [@ding-young]: https://github.com/ding-young
-[@mbrobbel]: https://github.com/mrbrobbel
+[@mbrobbel]: https://github.com/mbrobbel
 [@petern48]: https://github.com/petern48
 [@sdf-jkl]: https://github.com/sdf-jkl
 [@abacef]: https://github.com/abacef


### PR DESCRIPTION
- Closes  https://github.com/apache/arrow-rs/issues/8463

Preview URL: https://alamb.github.io/arrow-site/blog/2025/09/04/arrow-rs-57.0.0/

This release has a crazy amount of content so we should tell the world about it. Here are two related blogs:
- https://github.com/apache/arrow-site/pull/712
- https://github.com/apache/arrow-site/pull/711
