### PR TITLE
  [Website] Fix Content-Security-Policy header configuration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -25,13 +25,6 @@ Redirect permanent /datafusion-python https://datafusion.apache.org/python
 # redirect all ballista URLs to new website
 Redirect permanent /ballista https://datafusion.apache.org/ballista
 
-# Content-Security-Policy exceptions for kapa.ai bot and reCAPTCHA
-# See https://infra.apache.org/tools/csp.html for information on adding CSP exceptions
-#
-# kapa.ai bot integration: Approved in https://issues.apache.org/jira/browse/INFRA-26638
-# Domains required for kapa.ai widget functionality
-#
-# Google reCAPTCHA: Required for anti-spam protection on Apache event sites
-#
-# Apache community event sites: www.apachecon.com and www.communityovercode.org
+# Content-Security-Policy exceptions (see https://infra.apache.org/tools/csp.html)
+# kapa.ai domains approved in https://issues.apache.org/jira/browse/INFRA-26638
 SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://widget.kapa.ai/ https://proxy.kapa.ai/ https://kapa-widget-proxy-la7.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app/ https://metrics.kapa.ai/ https://www.gstatic.com/ https://www.google.com/ https://www.recaptcha.net/ https://recaptcha.net/ https://www.apachecon.com/ https://www.communityovercode.org/"


### PR DESCRIPTION
Switches from directly setting the Content-Security-Policy header to using Apache Infra's recommended SetEnv CSP_PROJECT_DOMAINS approach. This resolves  issue #723 by adding CSP exceptions rather than overriding the entire header.

Approval: https://issues.apache.org/jira/browse/INFRA-26638

We should test this when we merge it in case it breaks anything, as per previous updates with this.