### PR TITLE
Add DACP to Powered By Apache Arrow list

### DIFF
--- a/powered_by.md
+++ b/powered_by.md
@@ -237,7 +237,6 @@ short description of your use case.
   high-bandwidth output path for downstream analytics. This makes it easy and
   efficient to access security data via pyarrow and other available bindings.
 
-
 [1]: https://www.apache.org/foundation/marks/
 [2]: https://www.apache.org/foundation/marks/faq/
 [3]: https://parquet.apache.org/


### PR DESCRIPTION
Title: Add DACP to Powered By Apache Arrow list
Description:  
We'd like to add Data Access and Collaboration Protocol (DACP) to the "Powered By Apache Arrow" list.  

Project details:  
- Organization: Computer Network Information Center(CNIC), Chinese Academy of Science(CAS)
- Project URL: https://github.com/rdcn-link/dftp-dacp  
- Arrow components used: Apache Arrow Flight (for streaming data interactions)  

We confirm that the project complies with Apache Arrow's trademark and logo usage guidelines.  

Thank you for your review!
