### PR TITLE
Add homepage, description & labels to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -14,6 +14,11 @@
 # limitations under the License.
 
 github:
+  description: "Apache Arrow Website"
+  homepage: https://arrow.apache.org
+  labels:
+    - website
+    - jekyll
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
Adding the **_jekyll_** label so that its easier to find ASF projects using [Jekyll](https://jekyllrb.com/)

(I've created an [Infra PR](https://github.com/apache/infrastructure-website/pull/255) to add [this GitHub Query](https://github.com/search?q=topic%3Ajekyll+org%3Aapache&type=Repositories) to the [Infra Project Website page](https://infra.apache.org/project-site.html#sitemanagement))