### PR TITLE
[Website][R] Update docs/r/news/index.html

### DIFF
--- a/docs/r/news/index.html
+++ b/docs/r/news/index.html
@@ -91,10 +91,6 @@
 <li>
 <code><a href="https://rdrr.io/r/base/all.equal.html" class="external-link">all.equal()</a></code> S3 method is now correctly registered (<a href="https://github.com/MichaelChirico" class="external-link">@MichaelChirico</a>, <a href="https://github.com/apache/arrow/issues/49481" class="external-link">#49481</a>).</li>
 </ul></div>
-<div class="section level3">
-<h3 id="installation-24-0-0">Installation<a class="anchor" aria-label="anchor" href="#installation-24-0-0"></a></h3>
-<ul><li>arm64 (aarch64) Linux binaries are now available (<a href="https://github.com/apache/arrow/issues/48574" class="external-link">#48574</a>).</li>
-</ul></div>
 </div>
     <div class="section level2">
 <h2 class="pkg-version" data-toc-text="23.0.1.2" id="arrow-23012">arrow 23.0.1.2<a class="anchor" aria-label="anchor" href="#arrow-23012"></a></h2><p class="text-muted">CRAN release: 2026-03-25</p>

--- a/docs/r/news/index.html
+++ b/docs/r/news/index.html
@@ -73,7 +73,28 @@
     </div>
 
     <div class="section level2">
-<h2 class="pkg-version" data-toc-text="24.0.0" id="arrow-2400">arrow 24.0.0<a class="anchor" aria-label="anchor" href="#arrow-2400"></a></h2>
+<h2 class="pkg-version" data-toc-text="24.0.0" id="arrow-2400">arrow 24.0.0<a class="anchor" aria-label="anchor" href="#arrow-2400"></a></h2><p class="text-muted">CRAN release: 2026-04-29</p>
+<div class="section level3">
+<h3 id="new-features-24-0-0">New features<a class="anchor" aria-label="anchor" href="#new-features-24-0-0"></a></h3>
+<ul><li>
+<code><a href="https://dplyr.tidyverse.org/reference/when-any-all.html" class="external-link">dplyr::when_any()</a></code> and <code><a href="https://dplyr.tidyverse.org/reference/when-any-all.html" class="external-link">dplyr::when_all()</a></code> helper bindings (<a href="https://github.com/apache/arrow/issues/49535" class="external-link">#49535</a>).</li>
+<li>
+<code><a href="https://dplyr.tidyverse.org/reference/filter.html" class="external-link">dplyr::filter_out()</a></code> binding (<a href="https://github.com/larry77" class="external-link">@larry77</a>, <a href="https://github.com/apache/arrow/issues/49256" class="external-link">#49256</a>).</li>
+<li>
+<code><a href="https://dplyr.tidyverse.org/reference/recode-and-replace-values.html" class="external-link">dplyr::recode_values()</a></code>, <code><a href="https://dplyr.tidyverse.org/reference/recode-and-replace-values.html" class="external-link">dplyr::replace_values()</a></code>, and <code><a href="https://dplyr.tidyverse.org/reference/case-and-replace-when.html" class="external-link">dplyr::replace_when()</a></code> bindings (<a href="https://github.com/apache/arrow/issues/49536" class="external-link">#49536</a>).</li>
+<li>
+<code><a href="../reference/write_dataset.html">write_dataset()</a></code> gains a <code>preserve_order</code> argument to preserve row ordering within partitions (<a href="https://github.com/marberts" class="external-link">@marberts</a>, <a href="https://github.com/apache/arrow/issues/49343" class="external-link">#49343</a>).</li>
+</ul></div>
+<div class="section level3">
+<h3 id="minor-improvements-and-fixes-24-0-0">Minor improvements and fixes<a class="anchor" aria-label="anchor" href="#minor-improvements-and-fixes-24-0-0"></a></h3>
+<ul><li>Zero-length <code>POSIXct</code> objects with integer storage (as created by <code>as.POSIXct(NULL)</code> in R 4.5.2+) are now correctly mapped to timestamp type instead of integer (<a href="https://github.com/apache/arrow/issues/49619" class="external-link">#49619</a>).</li>
+<li>
+<code><a href="https://rdrr.io/r/base/all.equal.html" class="external-link">all.equal()</a></code> S3 method is now correctly registered (<a href="https://github.com/MichaelChirico" class="external-link">@MichaelChirico</a>, <a href="https://github.com/apache/arrow/issues/49481" class="external-link">#49481</a>).</li>
+</ul></div>
+<div class="section level3">
+<h3 id="installation-24-0-0">Installation<a class="anchor" aria-label="anchor" href="#installation-24-0-0"></a></h3>
+<ul><li>arm64 (aarch64) Linux binaries are now available (<a href="https://github.com/apache/arrow/issues/48574" class="external-link">#48574</a>).</li>
+</ul></div>
 </div>
     <div class="section level2">
 <h2 class="pkg-version" data-toc-text="23.0.1.2" id="arrow-23012">arrow 23.0.1.2<a class="anchor" aria-label="anchor" href="#arrow-23012"></a></h2><p class="text-muted">CRAN release: 2026-03-25</p>


### PR DESCRIPTION
This is a post release step, see https://github.com/apache/arrow/issues/49685.

I ran `pkgdown::build_news()` from the `maint-24.0.0-r` branch, copied docs/r/news/index.html to arrow-site/asf-site and staged just the hunk for the 24.0.0 news item (there were other changes).