### PR TITLE
chore: Fix grammar in PR preview comment

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -45,8 +45,8 @@ jobs:
           {
             echo "Preview URL: https://${fork_owner}.github.io/${fork_repository}"
             echo ""
-            echo "If the preview URL doesn't work, you may forget to configure your fork repository for preview."
-            echo "See ${configure_url} how to configure."
+            echo "If the preview URL doesn't work, you may have forgotten to configure your fork repository for preview."
+            echo "See ${configure_url} for instructions on how to configure."
           } | tee body.md
           gh pr comment ${PR_NUMBER} \
             --body-file body.md \


### PR DESCRIPTION
## What's Changed

This PR fixes some minor grammatical issues in the PR preview message. This was first caught in apache/arrow-erlang#99 when we were setting up previews based on the flow in this repository.
