### PR TITLE
[Website] Update Arrow governance roster

### DIFF
--- a/_data/committers.yml
+++ b/_data/committers.yml
@@ -123,6 +123,10 @@
   role: PMC
   alias: jakevin
   affiliation: SelectDB
+- name: Jeffrey Vo
+  role: PMC
+  alias: jeffreyvo
+  affiliation: None
 - name: Jonathan Keane
   role: PMC
   alias: jonkeane
@@ -348,10 +352,6 @@
   role: Committer
   alias: jayzhan
   affiliation: None
-- name: Jeffrey Vo
-  role: Committer
-  alias: jeffreyvo
-  affiliation: None
 - name: Ji Liu
   role: Committer
   alias: tianchen
@@ -456,6 +456,10 @@
   role: Committer
   alias: wayne
   affiliation: Greptime
+- name: Ryan Johnson
+  role: Committer
+  alias: scovich
+  affiliation: None
 - name: Sarah Gilmore
   role: Committer
   alias: sgilmore


### PR DESCRIPTION
## What changed

- Adds Ryan Johnson (@scovich) as an Arrow committer. See https://home.apache.org/phonebook.html?uid=scovich
- Moves Jeffrey Vo (@Jefffrey ) from committer to PMC on the governance roster -- see https://lists.apache.org/thread/v55trpp9zcpl1hfwq7qr3c3nf19lmg4s and https://home.apache.org/phonebook.html?uid=jeffreyvo

